### PR TITLE
[user-authz] Move the jq guard to the test class that executes jqFilter programs

### DIFF
--- a/modules/140-user-authz/webhooks/validating/identity_collision_test.py
+++ b/modules/140-user-authz/webhooks/validating/identity_collision_test.py
@@ -237,7 +237,6 @@ class TestIdentityCollisionWithAuthorizationRules(unittest.TestCase):
         self.assert_allowed_without_warnings(out)
 
 
-@unittest.skipUnless(shutil.which("jq"), "jq is required to execute the hook's jqFilter programs")
 class TestPlatformIdentitiesAreExempt(unittest.TestCase):
     """
     The installer applies the initial rule and the User it names from one manifest, and on a
@@ -319,6 +318,7 @@ class TestPlatformIdentitiesAreExempt(unittest.TestCase):
                              len(identity_collision.EXEMPT_USERS) + len(identity_collision.EXEMPT_GROUPS))
 
 
+@unittest.skipUnless(shutil.which("jq"), "jq is required to execute the hook's jqFilter programs")
 class TestSnapshotJQFilters(unittest.TestCase):
     """
     Run the jqFilter programs from CONFIG the way shell-operator would.


### PR DESCRIPTION
## Description

`identity_collision_test.py` contains two test classes with different needs. `TestPlatformIdentitiesAreExempt` only calls `hook.testrun` and never shells out to `jq`. `TestSnapshotJQFilters` executes the hook's `jqFilter` programs through the `jq` binary, the way shell-operator does for the real snapshots.

The `skipUnless(shutil.which("jq"))` guard was attached to the first class instead of the second. This commit moves it to the class that actually needs the binary. No test logic is changed.

## Why do we need it, and what problem does it solve?

The reference runner `testing/webhooks/test.sh` installs `jq` into the container, but the Python webhook tests are also executed by runners whose image does not ship it. Without the binary the suite currently skips eight tests that could have run and fails five others with `FileNotFoundError: [Errno 2] No such file or directory: 'jq'`, which says nothing about the code under test.

After the move the filter tests skip cleanly where `jq` is unavailable and still run wherever it is present, so the suite reports a meaningful result in both environments.

Verified locally on both paths:

* `jq` present: 36 passed.
* `jq` absent from `PATH`: 31 passed, 5 skipped, exit code 0.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: chore
summary: Skip the jqFilter unit tests when the jq binary is unavailable instead of failing them.
impact_level: low
```
