### PR TITLE
Fix tests for old branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,9 +172,6 @@ tests-webhooks: bin/yq ## Run python webhooks unit tests.
 ## No-op stub. The tests job runs on pull_request_target, so GitHub takes the
 ## workflow from the default branch while the checkout is this branch, and main
 ## calls `make tests-controller tests-modules test-crd-enricher`. pkg/crd-enricher
-## was added after 1.73 was cut, so without this target make aborts the whole job
-## with `No rule to make target`. Replace the body with the real invocation if the
-## module is ever backported here.
 .PHONY: test-crd-enricher
 test-crd-enricher: ## Stub for the crd-enricher tests: the module does not exist in this branch.
 	@echo "pkg/crd-enricher is absent in this branch, skipping test-crd-enricher."

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,16 @@ tests-controller: ## Run deckhouse-controller unit tests.
 tests-webhooks: bin/yq ## Run python webhooks unit tests.
 	./testing/webhooks/run.sh
 
+## No-op stub. The tests job runs on pull_request_target, so GitHub takes the
+## workflow from the default branch while the checkout is this branch, and main
+## calls `make tests-controller tests-modules test-crd-enricher`. pkg/crd-enricher
+## was added after 1.73 was cut, so without this target make aborts the whole job
+## with `No rule to make target`. Replace the body with the real invocation if the
+## module is ever backported here.
+.PHONY: test-crd-enricher
+test-crd-enricher: ## Stub for the crd-enricher tests: the module does not exist in this branch.
+	@echo "pkg/crd-enricher is absent in this branch, skipping test-crd-enricher."
+
 .PHONY: validate
 validate: ## Check common patterns through all modules.
 	go test -tags=validation -run Validation -timeout=${TESTS_TIMEOUT} ./testing/...

--- a/tools/docs/spelling/validate_dictionary_sync.sh
+++ b/tools/docs/spelling/validate_dictionary_sync.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# No-op stub.
+#
+# The Validations workflow runs on pull_request_target, so GitHub takes it from
+# the default branch while the checkout is this branch. main calls this script
+# to verify that tools/docs/spelling/wordlist and dictionaries/dev_OPS.dic stay
+# in sync; the check landed after 1.73 was cut, so every pull request into this
+# branch died here with exit 127 over a validation the branch never carried.
+#
+# Keeping an executable stub lets the step succeed without pretending the check
+# ran. Replace it with the real script from main if the check is backported.
+
+set -Eeo pipefail
+
+echo "::notice::validate_dictionary_sync.sh is a no-op stub in this branch, the wordlist <-> dev_OPS.dic sync is not verified here"
+
+exit 0

--- a/tools/docs/spelling/validate_dictionary_sync.sh
+++ b/tools/docs/spelling/validate_dictionary_sync.sh
@@ -19,8 +19,6 @@
 # The Validations workflow runs on pull_request_target, so GitHub takes it from
 # the default branch while the checkout is this branch. main calls this script
 # to verify that tools/docs/spelling/wordlist and dictionaries/dev_OPS.dic stay
-# in sync; the check landed after 1.73 was cut, so every pull request into this
-# branch died here with exit 127 over a validation the branch never carried.
 #
 # Keeping an executable stub lets the step succeed without pretending the check
 # ran. Replace it with the real script from main if the check is backported.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix tests for old branches.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This PR adds stub script and target for old branch to prevent CI failure on PRs.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix tests for old branches
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
