### PR TITLE
[node-manager] Keep foreign node taints on first template apply

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/constants.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/constants.go
@@ -30,4 +30,8 @@ const (
 	heartbeatAnnotationKey            = "kubevirt.internal.virtualization.deckhouse.io/heartbeat"
 	metalLBmemberLabelKey             = "l2-load-balancer.network.deckhouse.io/member"
 	controlPlaneTaintKey              = "node-role.kubernetes.io/control-plane"
+	masterNodeGroupName               = "master"
+	nodeRoleLabelPrefix               = "node-role.kubernetes.io/"
+	nodeTypeLabel                     = "node.deckhouse.io/type"
+	scaleDownDisabledAnnotation       = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
 )

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/coverage_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/coverage_test.go
@@ -537,10 +537,11 @@ func TestTaintSliceEqual(t *testing.T) {
 // --- applyTemplateTaints: removal + nil/nil branches ---
 
 func TestApplyTemplateTaints(t *testing.T) {
-	t.Run("nil template and lastApplied returns empty changed", func(t *testing.T) {
-		got, changed := applyTemplateTaints(nil, nil, nil)
-		if !changed || len(got) != 0 {
-			t.Fatalf("expected empty+changed, got %+v changed=%v", got, changed)
+	t.Run("nil template and lastApplied keeps actual unchanged", func(t *testing.T) {
+		actual := []corev1.Taint{{Key: "dedicated", Effect: corev1.TaintEffectNoSchedule}}
+		got, changed := applyTemplateTaints(actual, nil, nil)
+		if changed || len(got) != 1 || got[0].Key != "dedicated" {
+			t.Fatalf("expected actual kept unchanged, got %+v changed=%v", got, changed)
 		}
 	})
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/e2e_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/e2e_test.go
@@ -81,6 +81,10 @@ func uninitializedTaint() corev1.Taint {
 	return corev1.Taint{Key: nodeUninitializedTaintKey, Effect: corev1.TaintEffectNoSchedule}
 }
 
+func ccmUninitializedTaint() corev1.Taint {
+	return corev1.Taint{Key: "node.cloudprovider.kubernetes.io/uninitialized", Value: "true", Effect: corev1.TaintEffectNoSchedule}
+}
+
 var _ = AfterEach(func() {
 	Eventually(func(g Gomega) {
 		nodeList := &corev1.NodeList{}
@@ -136,6 +140,24 @@ var _ = Describe("NodeTemplate controller applies the NodeGroup template to its 
 		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
 	})
 
+	// CCM sets providerID only while its own uninitialized taint is present.
+	It("keeps foreign taints on the first reconcile of a node in a group without template taints", func() {
+		ngName := testenv.UniqueName("frontend")
+		createNodeGroup(ngName, v1.NodeTypeCloudPermanent, nil)
+
+		ccmTaint := ccmUninitializedTaint()
+		bashibleTaint := corev1.Taint{Key: "node.deckhouse.io/bashible-uninitialized", Effect: corev1.TaintEffectNoSchedule}
+		nodeName := testenv.UniqueName("frontend-node")
+		createNode(nodeName, ngName, nil, nil, []corev1.Taint{ccmTaint, bashibleTaint, uninitializedTaint()})
+
+		Eventually(func(g Gomega) {
+			node := getNodeFromAPI(nodeName)
+			g.Expect(node.Annotations).To(HaveKey(lastAppliedNodeTemplateAnnotation))
+			g.Expect(node.Spec.Taints).To(ContainElements(ccmTaint, bashibleTaint))
+			g.Expect(taintSliceHasKey(node.Spec.Taints, nodeUninitializedTaintKey)).To(BeFalse())
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+	})
+
 	It("applies master role labels and removes the legacy master taint not present in the template", func() {
 		createNodeGroup("master", v1.NodeTypeCloudPermanent, nil)
 
@@ -150,6 +172,27 @@ var _ = Describe("NodeTemplate controller applies the NodeGroup template to its 
 			g.Expect(node.Labels).To(HaveKey(masterNodeRoleKey))
 			g.Expect(node.Labels).To(HaveKeyWithValue(nodeTypeLabel, string(v1.NodeTypeCloudPermanent)))
 			g.Expect(taintSliceHasKey(node.Spec.Taints, masterNodeRoleKey)).To(BeFalse())
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+	})
+
+	// Bootstrap taints the first master with control-plane before any template exists.
+	It("drops the bootstrap control-plane taint on a master whose template has no taints and keeps foreign taints", func() {
+		createNodeGroup("master", v1.NodeTypeCloudPermanent, nil)
+
+		ccmTaint := ccmUninitializedTaint()
+		nodeName := testenv.UniqueName("master-node")
+		createNode(nodeName, "master", nil, nil, []corev1.Taint{
+			{Key: controlPlaneTaintKey, Effect: corev1.TaintEffectNoSchedule},
+			ccmTaint,
+			uninitializedTaint(),
+		})
+
+		Eventually(func(g Gomega) {
+			node := getNodeFromAPI(nodeName)
+			g.Expect(node.Annotations).To(HaveKey(lastAppliedNodeTemplateAnnotation))
+			g.Expect(node.Spec.Taints).To(ContainElements(ccmTaint))
+			g.Expect(taintSliceHasKey(node.Spec.Taints, controlPlaneTaintKey)).To(BeFalse())
+			g.Expect(taintSliceHasKey(node.Spec.Taints, nodeUninitializedTaintKey)).To(BeFalse())
 		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
 	})
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/e2e_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/e2e_test.go
@@ -72,6 +72,21 @@ func getNodeFromAPI(name string) *corev1.Node {
 	return node
 }
 
+func setTemplateTaints(ngName string, taints []corev1.Taint) {
+	Eventually(func(g Gomega) {
+		ng := &v1.NodeGroup{}
+		g.Expect(k8sClient.Get(suiteCtx, types.NamespacedName{Name: ngName}, ng)).To(Succeed())
+		ng.Spec.NodeTemplate = &v1.NodeTemplate{Taints: taints}
+		g.Expect(k8sClient.Update(suiteCtx, ng)).To(Succeed())
+	}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+}
+
+func waitAdopted(nodeName string) {
+	Eventually(func(g Gomega) {
+		g.Expect(getNodeFromAPI(nodeName).Annotations).To(HaveKey(lastAppliedNodeTemplateAnnotation))
+	}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+}
+
 func uninitializedTaint() corev1.Taint {
 	return corev1.Taint{Key: nodeUninitializedTaintKey, Effect: corev1.TaintEffectNoSchedule}
 }
@@ -188,6 +203,47 @@ var _ = Describe("NodeTemplate controller applies the NodeGroup template to its 
 			g.Expect(node.Spec.Taints).To(ContainElements(ccmTaint))
 			g.Expect(taintSliceHasKey(node.Spec.Taints, controlPlaneTaintKey)).To(BeFalse())
 			g.Expect(taintSliceHasKey(node.Spec.Taints, nodeUninitializedTaintKey)).To(BeFalse())
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+	})
+
+	It("keeps a taint added by hand after the node was adopted", func() {
+		ngName := testenv.UniqueName("adopted")
+		createNodeGroup(ngName, v1.NodeTypeStatic, nil)
+		nodeName := testenv.UniqueName("adopted-node")
+		createNode(nodeName, ngName, nil, nil, []corev1.Taint{uninitializedTaint()})
+		waitAdopted(nodeName)
+
+		byHand := corev1.Taint{Key: "by-hand", Effect: corev1.TaintEffectNoSchedule}
+		Eventually(func(g Gomega) {
+			node := getNodeFromAPI(nodeName)
+			node.Spec.Taints = append(node.Spec.Taints, byHand)
+			g.Expect(k8sClient.Update(suiteCtx, node)).To(Succeed())
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+
+		Consistently(func(g Gomega) {
+			g.Expect(getNodeFromAPI(nodeName).Spec.Taints).To(ContainElements(byHand))
+		}, testenv.NegativeCheckDuration, testenv.EventuallyPoll).Should(Succeed())
+	})
+
+	It("follows template taint changes on an adopted node and keeps foreign taints", func() {
+		ngName := testenv.UniqueName("templated")
+		createNodeGroup(ngName, v1.NodeTypeStatic, nil)
+		foreign := corev1.Taint{Key: "foreign", Effect: corev1.TaintEffectNoSchedule}
+		nodeName := testenv.UniqueName("templated-node")
+		createNode(nodeName, ngName, nil, nil, []corev1.Taint{foreign, uninitializedTaint()})
+		waitAdopted(nodeName)
+
+		dedicated := corev1.Taint{Key: "dedicated", Value: "workload", Effect: corev1.TaintEffectNoSchedule}
+		setTemplateTaints(ngName, []corev1.Taint{dedicated})
+		Eventually(func(g Gomega) {
+			g.Expect(getNodeFromAPI(nodeName).Spec.Taints).To(ContainElements(dedicated, foreign))
+		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
+
+		setTemplateTaints(ngName, nil)
+		Eventually(func(g Gomega) {
+			node := getNodeFromAPI(nodeName)
+			g.Expect(taintSliceHasKey(node.Spec.Taints, "dedicated")).To(BeFalse())
+			g.Expect(node.Spec.Taints).To(ContainElements(foreign))
 		}, testenv.EventuallyTimeout, testenv.EventuallyPoll).Should(Succeed())
 	})
 

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/e2e_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/e2e_test.go
@@ -29,11 +29,6 @@ import (
 	"github.com/deckhouse/node-controller/internal/testenv"
 )
 
-const (
-	scaleDownDisabledAnnotation = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
-	nodeTypeLabel               = "node.deckhouse.io/type"
-)
-
 // createNodeGroup creates a NodeGroup with the given node type and optional template. For
 // CloudEphemeral groups the CRD's oneOf schema requires spec.cloudInstances, so a minimal valid
 // block is added in that case.

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/metrics.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/metrics.go
@@ -57,7 +57,7 @@ func (r *Reconciler) syncUnmanagedNodesMetric(nodes []corev1.Node) {
 func (r *Reconciler) syncMissingMasterTaintMetric(nodeGroups []v1.NodeGroup, nodes []corev1.Node) {
 	missingMasterTaintGauge.Reset()
 	for i := range nodeGroups {
-		if nodeGroups[i].Name != "master" {
+		if nodeGroups[i].Name != masterNodeGroupName {
 			continue
 		}
 		if len(nodeGroups) == 1 && len(nodes) == 1 {
@@ -72,7 +72,7 @@ func (r *Reconciler) syncMissingMasterTaintMetric(nodeGroups []v1.NodeGroup, nod
 			}
 		}
 		if controlPlaneTaintMissing {
-			missingMasterTaintGauge.WithLabelValues("master").Set(1)
+			missingMasterTaintGauge.WithLabelValues(masterNodeGroupName).Set(1)
 		}
 		return
 	}

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/reconcile_service.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/reconcile_service.go
@@ -51,7 +51,7 @@ func (r *Reconciler) reconcileNode(ctx context.Context, node *corev1.Node, ng *v
 		}
 	}
 
-	if ng.Name == "master" {
+	if ng.Name == masterNodeGroupName {
 		logger.V(1).Info("applying master node role labels and fixing master taints", "node", node.Name)
 		if working.Labels == nil {
 			working.Labels = make(map[string]string)
@@ -67,7 +67,7 @@ func (r *Reconciler) reconcileNode(ctx context.Context, node *corev1.Node, ng *v
 		if working.Annotations == nil {
 			working.Annotations = make(map[string]string)
 		}
-		working.Annotations["cluster-autoscaler.kubernetes.io/scale-down-disabled"] = "true"
+		working.Annotations[scaleDownDisabledAnnotation] = "true"
 	}
 
 	if !nodeChanged(base, working) {

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/taints.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/taints.go
@@ -134,11 +134,22 @@ func taintToString(t corev1.Taint) string {
 	return t.Key + "=" + t.Value + ":" + string(t.Effect)
 }
 
-func applyTemplateTaints(actual, template, lastApplied []corev1.Taint) ([]corev1.Taint, bool) {
-	if template == nil && lastApplied == nil {
-		return []corev1.Taint{}, true
+// ownedTaints lists the taints node-controller may remove from a node: the ones it applied from the
+// template before, or on the first reconcile of a master the control-plane taint cluster bootstrap puts
+// there (candi/bashible/common-steps/cluster-bootstrap/072_install_control_plane.sh.tpl).
+func ownedTaints(lastApplied *v1.NodeTemplate, nodeGroup *v1.NodeGroup) []corev1.Taint {
+	if lastApplied != nil {
+		return lastApplied.Taints
 	}
+	if nodeGroup.Name == "master" {
+		return []corev1.Taint{{Key: controlPlaneTaintKey, Effect: corev1.TaintEffectNoSchedule}}
+	}
+	return nil
+}
 
+// applyTemplateTaints merges template taints into the node taints. An owned taint that left the
+// template is dropped. Every other taint on the node (CCM, CSI, bashible, set by hand) is kept as is.
+func applyTemplateTaints(actual, template, owned []corev1.Taint) ([]corev1.Taint, bool) {
 	changed := false
 
 	// Build set of template keys
@@ -147,18 +158,17 @@ func applyTemplateTaints(actual, template, lastApplied []corev1.Taint) ([]corev1
 		templateKeys[t.Key] = struct{}{}
 	}
 
-	// Find keys to remove: in lastApplied but not in template
-	removeKeys := make(map[string]struct{})
-	for _, t := range lastApplied {
+	staleOwnedKeys := make(map[string]struct{})
+	for _, t := range owned {
 		if _, found := templateKeys[t.Key]; !found {
-			removeKeys[t.Key] = struct{}{}
+			staleOwnedKeys[t.Key] = struct{}{}
 		}
 	}
 
 	// Build result map keyed by taint.Key (one taint per key, like original)
 	newTaints := make(map[string]corev1.Taint, len(actual)+len(template))
 	for _, t := range actual {
-		if _, shouldRemove := removeKeys[t.Key]; shouldRemove {
+		if _, stale := staleOwnedKeys[t.Key]; stale {
 			changed = true
 			continue
 		}

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/taints.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/taints.go
@@ -17,6 +17,8 @@ limitations under the License.
 package nodetemplate
 
 import (
+	"cmp"
+	"maps"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +26,8 @@ import (
 	v1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
 )
 
+// fixMasterTaints removes the legacy node-role.kubernetes.io/master taint from a master node when the
+// NodeGroup template does not declare it and the node carries no control-plane taint yet.
 func fixMasterTaints(nodeTaints, ngTaints []corev1.Taint) []corev1.Taint {
 	if len(nodeTaints) == 0 {
 		return nodeTaints
@@ -55,6 +59,8 @@ func fixMasterTaints(nodeTaints, ngTaints []corev1.Taint) []corev1.Taint {
 	return nodeTaints
 }
 
+// fixCloudNodeTaints clears the uninitialized taint on a CloudEphemeral node once its taints already
+// include the template taints, which the machine controller sets. Until then the node is left alone.
 func fixCloudNodeTaints(nodeObj *corev1.Node, nodeGroup *v1.NodeGroup) {
 	newTaints := mergeTaints(nodeObj.Spec.Taints, getTemplateTaints(nodeGroup))
 	if !taintSliceEqual(newTaints, nodeObj.Spec.Taints) {
@@ -141,59 +147,31 @@ func ownedTaints(lastApplied *v1.NodeTemplate, nodeGroup *v1.NodeGroup) []corev1
 	if lastApplied != nil {
 		return lastApplied.Taints
 	}
-	if nodeGroup.Name == "master" {
+	if nodeGroup.Name == masterNodeGroupName {
 		return []corev1.Taint{{Key: controlPlaneTaintKey, Effect: corev1.TaintEffectNoSchedule}}
 	}
 	return nil
 }
 
-// applyTemplateTaints merges template taints into the node taints. An owned taint that left the
-// template is dropped. Every other taint on the node (CCM, CSI, bashible, set by hand) is kept as is.
+// applyTemplateTaints merges template taints into the node taints, one taint per key. An owned taint
+// that left the template is dropped. Every other taint on the node (CCM, CSI, bashible, set by hand)
+// is kept as is.
 func applyTemplateTaints(actual, template, owned []corev1.Taint) ([]corev1.Taint, bool) {
 	changed := false
-
-	// Build set of template keys
-	templateKeys := make(map[string]struct{}, len(template))
-	for _, t := range template {
-		templateKeys[t.Key] = struct{}{}
-	}
-
-	staleOwnedKeys := make(map[string]struct{})
-	for _, t := range owned {
-		if _, found := templateKeys[t.Key]; !found {
-			staleOwnedKeys[t.Key] = struct{}{}
-		}
-	}
-
-	// Build result map keyed by taint.Key (one taint per key, like original)
-	newTaints := make(map[string]corev1.Taint, len(actual)+len(template))
+	byKey := make(map[string]corev1.Taint, len(actual)+len(template))
 	for _, t := range actual {
-		if _, stale := staleOwnedKeys[t.Key]; stale {
+		if taintSliceHasKey(owned, t.Key) && !taintSliceHasKey(template, t.Key) {
 			changed = true
 			continue
 		}
-		newTaints[t.Key] = t
+		byKey[t.Key] = t
 	}
-
 	for _, t := range template {
-		oldTaint, ok := newTaints[t.Key]
-		if !ok || taintToString(oldTaint) != taintToString(t) {
+		if old, ok := byKey[t.Key]; !ok || taintToString(old) != taintToString(t) {
 			changed = true
 		}
-		newTaints[t.Key] = t
+		byKey[t.Key] = t
 	}
-
-	// Sort by key and return as slice
-	keys := make([]string, 0, len(newTaints))
-	for k := range newTaints {
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-
-	result := make([]corev1.Taint, 0, len(newTaints))
-	for _, k := range keys {
-		result = append(result, newTaints[k])
-	}
-
-	return result, changed
+	sorted := slices.SortedFunc(maps.Values(byKey), func(a, b corev1.Taint) int { return cmp.Compare(a.Key, b.Key) })
+	return sorted, changed
 }

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/template_service.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/template_service.go
@@ -93,11 +93,7 @@ func applyNodeTemplate(nodeObj *corev1.Node, nodeGroup *v1.NodeGroup) error {
 	}
 	newAnnotations[lastAppliedNodeTemplateAnnotation] = string(newLastApplied)
 
-	var lastTaints []corev1.Taint
-	if lastAppliedNodeTemplate != nil {
-		lastTaints = lastAppliedNodeTemplate.Taints
-	}
-	newTaints, taintsChanged := applyTemplateTaints(nodeObj.Spec.Taints, templateTaints, lastTaints)
+	newTaints, taintsChanged := applyTemplateTaints(nodeObj.Spec.Taints, templateTaints, ownedTaints(lastAppliedNodeTemplate, nodeGroup))
 	if taintSliceHasKey(newTaints, nodeUninitializedTaintKey) {
 		taintsChanged = true
 		newTaints = taintSliceWithoutKey(newTaints, nodeUninitializedTaintKey)

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/template_service.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/nodetemplate/template_service.go
@@ -25,75 +25,21 @@ import (
 	v1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
 )
 
+// applyNodeTemplate brings node labels, annotations and taints in line with the NodeGroup template:
+// template entries are set, entries a previous template declared and this one dropped are removed,
+// everything else stays. nodeObj is changed in place, the caller patches it.
 func applyNodeTemplate(nodeObj *corev1.Node, nodeGroup *v1.NodeGroup) error {
-	var lastAppliedNodeTemplate *v1.NodeTemplate
-
-	if nodeObj.Annotations != nil {
-		if lastApplied := nodeObj.Annotations[lastAppliedNodeTemplateAnnotation]; lastApplied != "" {
-			lant := v1.NodeTemplate{}
-			if err := json.Unmarshal([]byte(lastApplied), &lant); err != nil {
-				return fmt.Errorf("parse last applied node template: %w", err)
-			}
-			lastAppliedNodeTemplate = &lant
-		}
-	}
-
-	actualLabels := cloneStringMap(nodeObj.Labels)
-	delete(actualLabels, metalLBmemberLabelKey)
-	desiredLabels := getTemplateLabels(nodeGroup)
-	var lastLabels map[string]string
-	if lastAppliedNodeTemplate != nil {
-		lastLabels = lastAppliedNodeTemplate.Labels
-	}
-	newLabels, labelsChanged := applyTemplateMap(actualLabels, desiredLabels, lastLabels)
-
-	roleLabel := "node-role.kubernetes.io/" + nodeGroup.Name
-	if value, ok := newLabels[roleLabel]; !ok || value != "" {
-		labelsChanged = true
-	}
-	newLabels[roleLabel] = ""
-
-	nodeType := string(nodeGroup.Spec.NodeType)
-	if value, ok := newLabels["node.deckhouse.io/type"]; !ok || value != nodeType {
-		labelsChanged = true
-	}
-	newLabels["node.deckhouse.io/type"] = nodeType
-
-	actualAnnotations := cloneStringMap(nodeObj.Annotations)
-	delete(actualAnnotations, heartbeatAnnotationKey)
-	desiredAnnotations := getTemplateAnnotations(nodeGroup)
-	var lastAnnotations map[string]string
-	if lastAppliedNodeTemplate != nil {
-		lastAnnotations = lastAppliedNodeTemplate.Annotations
-	}
-	newAnnotations, annotationsChanged := applyTemplateMap(actualAnnotations, desiredAnnotations, lastAnnotations)
-
-	lastAppliedMap := map[string]interface{}{
-		"annotations": map[string]string{},
-		"labels":      map[string]string{},
-		"taints":      make([]corev1.Taint, 0),
-	}
-	if len(desiredAnnotations) > 0 {
-		lastAppliedMap["annotations"] = desiredAnnotations
-	}
-	if len(desiredLabels) > 0 {
-		lastAppliedMap["labels"] = desiredLabels
-	}
-	templateTaints := getTemplateTaints(nodeGroup)
-	if len(templateTaints) > 0 {
-		lastAppliedMap["taints"] = templateTaints
-	}
-
-	newLastApplied, err := json.Marshal(lastAppliedMap)
+	lastApplied, err := parseLastAppliedNodeTemplate(nodeObj)
 	if err != nil {
-		return fmt.Errorf("marshal last applied node template: %w", err)
+		return err
 	}
-	if value, ok := newAnnotations[lastAppliedNodeTemplateAnnotation]; !ok || value != string(newLastApplied) {
-		annotationsChanged = true
-	}
-	newAnnotations[lastAppliedNodeTemplateAnnotation] = string(newLastApplied)
 
-	newTaints, taintsChanged := applyTemplateTaints(nodeObj.Spec.Taints, templateTaints, ownedTaints(lastAppliedNodeTemplate, nodeGroup))
+	newLabels, labelsChanged := templateLabels(nodeObj, nodeGroup, lastApplied)
+	newAnnotations, annotationsChanged, err := templateAnnotations(nodeObj, nodeGroup, lastApplied)
+	if err != nil {
+		return err
+	}
+	newTaints, taintsChanged := applyTemplateTaints(nodeObj.Spec.Taints, getTemplateTaints(nodeGroup), ownedTaints(lastApplied, nodeGroup))
 	if taintSliceHasKey(newTaints, nodeUninitializedTaintKey) {
 		taintsChanged = true
 		newTaints = taintSliceWithoutKey(newTaints, nodeUninitializedTaintKey)
@@ -106,16 +52,100 @@ func applyNodeTemplate(nodeObj *corev1.Node, nodeGroup *v1.NodeGroup) error {
 		nodeObj.Annotations = newAnnotations
 	}
 	if taintsChanged {
+		nodeObj.Spec.Taints = newTaints
 		if len(newTaints) == 0 {
 			nodeObj.Spec.Taints = nil
-		} else {
-			nodeObj.Spec.Taints = newTaints
 		}
 	}
-
 	return nil
 }
 
+// parseLastAppliedNodeTemplate reads the template applied by the previous reconcile from the node
+// annotation. nil means the node has not been reconciled yet.
+func parseLastAppliedNodeTemplate(nodeObj *corev1.Node) (*v1.NodeTemplate, error) {
+	raw := nodeObj.Annotations[lastAppliedNodeTemplateAnnotation]
+	if raw == "" {
+		return nil, nil
+	}
+	var lastApplied v1.NodeTemplate
+	if err := json.Unmarshal([]byte(raw), &lastApplied); err != nil {
+		return nil, fmt.Errorf("parse last applied node template: %w", err)
+	}
+	return &lastApplied, nil
+}
+
+// templateLabels merges template labels into the node labels and sets the system labels: the role
+// label named after the NodeGroup and the node type. The MetalLB member label is dropped from the copy.
+func templateLabels(nodeObj *corev1.Node, nodeGroup *v1.NodeGroup, lastApplied *v1.NodeTemplate) (map[string]string, bool) {
+	actual := cloneStringMap(nodeObj.Labels)
+	delete(actual, metalLBmemberLabelKey)
+	var last map[string]string
+	if lastApplied != nil {
+		last = lastApplied.Labels
+	}
+	labels, changed := applyTemplateMap(actual, getTemplateLabels(nodeGroup), last)
+
+	systemLabels := map[string]string{
+		nodeRoleLabelPrefix + nodeGroup.Name: "",
+		nodeTypeLabel:                        string(nodeGroup.Spec.NodeType),
+	}
+	for key, value := range systemLabels {
+		if old, ok := labels[key]; !ok || old != value {
+			changed = true
+		}
+		labels[key] = value
+	}
+	return labels, changed
+}
+
+// templateAnnotations merges template annotations into the node annotations and records the template
+// being applied in the last-applied annotation. The kubevirt heartbeat annotation is dropped from the copy.
+func templateAnnotations(nodeObj *corev1.Node, nodeGroup *v1.NodeGroup, lastApplied *v1.NodeTemplate) (map[string]string, bool, error) {
+	actual := cloneStringMap(nodeObj.Annotations)
+	delete(actual, heartbeatAnnotationKey)
+	var last map[string]string
+	if lastApplied != nil {
+		last = lastApplied.Annotations
+	}
+	annotations, changed := applyTemplateMap(actual, getTemplateAnnotations(nodeGroup), last)
+
+	newLastApplied, err := marshalLastAppliedNodeTemplate(nodeGroup)
+	if err != nil {
+		return nil, false, err
+	}
+	if annotations[lastAppliedNodeTemplateAnnotation] != newLastApplied {
+		changed = true
+	}
+	annotations[lastAppliedNodeTemplateAnnotation] = newLastApplied
+	return annotations, changed, nil
+}
+
+// marshalLastAppliedNodeTemplate serializes the template for the last-applied annotation. All three
+// keys are always present: the format is shared with the pre-2026 hook.
+func marshalLastAppliedNodeTemplate(nodeGroup *v1.NodeGroup) (string, error) {
+	lastApplied := map[string]any{
+		"annotations": map[string]string{},
+		"labels":      map[string]string{},
+		"taints":      []corev1.Taint{},
+	}
+	if annotations := getTemplateAnnotations(nodeGroup); len(annotations) > 0 {
+		lastApplied["annotations"] = annotations
+	}
+	if labels := getTemplateLabels(nodeGroup); len(labels) > 0 {
+		lastApplied["labels"] = labels
+	}
+	if taints := getTemplateTaints(nodeGroup); len(taints) > 0 {
+		lastApplied["taints"] = taints
+	}
+	raw, err := json.Marshal(lastApplied)
+	if err != nil {
+		return "", fmt.Errorf("marshal last applied node template: %w", err)
+	}
+	return string(raw), nil
+}
+
+// applyTemplateMap is the label and annotation counterpart of applyTemplateTaints: template entries
+// are set, keys that were in lastApplied but left the template are removed, the rest is kept.
 func applyTemplateMap(actual, template, lastApplied map[string]string) (map[string]string, bool) {
 	changed := false
 	excess := excessMapKeys(lastApplied, template)
@@ -140,6 +170,7 @@ func applyTemplateMap(actual, template, lastApplied map[string]string) (map[stri
 	return newMap, changed
 }
 
+// excessMapKeys returns the keys present in a but not in b.
 func excessMapKeys(a, b map[string]string) map[string]struct{} {
 	onlyA := make(map[string]struct{}, len(a))
 	for k := range a {


### PR DESCRIPTION
## Description

node-controller merges template taints into node taints and removes only the taints it set before (tracked in the last-applied annotation). A shortcut from 2021 skipped the merge on the first reconcile when the template had no taints and wrote an empty list, so fresh Static and CloudPermanent nodes lost the CCM, CSI and bashible taints. The same code lived in `go_lib/taints` before node-controller, reproduced on v1.76.13.

The shortcut is removed. The bootstrap `control-plane` taint on the first master still follows the template, so a `master` NodeGroup with an empty taint list keeps working. Also: `applyNodeTemplate` split into small functions, envtest added. Supersedes #21504.

## Why do we need it, and what problem does it solve?

CCM sets `providerID` only while its `uninitialized` taint is present. If the taint is removed while CCM has no leader (multi-master scale-up, CCM restart), the node never gets `providerID` and LoadBalancer sync fails. Seen on Yandex Cloud. Nodes already affected need the taint added back by hand.

## Why do we need it in the patch release (if we do)?

Affected clusters get nodes without `providerID`. Small change, covered by tests that fail on the old code.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: node-controller no longer removes taints set by other components on the first reconcile of Static and CloudPermanent nodes.
impact_level: default
```
