### PR TITLE
Bump werf version to v2.78.1-dk.1 and add build-report-operations

### DIFF
--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -1,5 +1,5 @@
 # WERF version for CI workflows. Read at runtime from this file by read_werf_version_step.
-WERF_VERSION: "v2.77.0-dk.1"
+WERF_VERSION: "v2.78.1-dk.1"
 
 {!{ define "werf_envs" }!}
 # <template: werf_envs>

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -305,6 +305,7 @@ steps:
       werf build \
         --parallel=true --parallel-tasks-limit=5 \
         --save-build-report=true \
+        --build-report-operations=true \
         --build-report-path images_tags_werf.json
 
       # Publish images for Git branch.
@@ -494,6 +495,7 @@ steps:
         --parallel=true --parallel-tasks-limit=5 \
         --save-build-report=true \
         --final-images-only=true \
+        --build-report-operations=true \
         --build-report-path images_tags_werf.json
 
       TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"

--- a/.github/ci_templates/build_fuzz.yml
+++ b/.github/ci_templates/build_fuzz.yml
@@ -134,6 +134,7 @@ steps:
         --insecure-registry \
         --parallel=true --parallel-tasks-limit=10 \
         --save-build-report=true \
+        --build-report-operations=true \
         --build-report-path images_fuzz_tags_werf.json
 
 {!{- if not $isDev }!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -704,6 +704,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -1010,6 +1011,7 @@ jobs:
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
             --final-images-only=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
@@ -1261,6 +1263,7 @@ jobs:
             --insecure-registry \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_fuzz_tags_werf.json
 
     # </template: build_fuzz_template>
@@ -1695,6 +1698,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -2096,6 +2100,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -2497,6 +2502,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -2898,6 +2904,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -3299,6 +3306,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -3700,6 +3708,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -466,6 +466,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -753,6 +754,7 @@ jobs:
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
             --final-images-only=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
@@ -998,6 +1000,7 @@ jobs:
             --insecure-registry \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_fuzz_tags_werf.json
           command -v jq >/dev/null 2>&1 || {
             echo "jq is required"

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -466,6 +466,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -753,6 +754,7 @@ jobs:
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
             --final-images-only=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
@@ -1188,6 +1190,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -1597,6 +1600,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -2006,6 +2010,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -2415,6 +2420,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -2824,6 +2830,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -3233,6 +3240,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -597,6 +597,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -1038,6 +1039,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -1480,6 +1482,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -1922,6 +1925,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -2364,6 +2368,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -2806,6 +2811,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -786,7 +786,6 @@ jobs:
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
             --build-report-operations=true \
-            --log-debug=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -1217,7 +1216,6 @@ jobs:
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
             --build-report-operations=true \
-            --log-debug=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -785,6 +785,8 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
+            --log-debug=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.
@@ -1214,6 +1216,8 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
+            --log-debug=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -462,6 +462,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=5 \
             --save-build-report=true \
+            --build-report-operations=true \
             --build-report-path images_tags_werf.json
 
           # Publish images for Git branch.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bump werf version to v2.78.1-dk.1 It opens ability to use build-report-operations
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We need stats about push, build and etc without enabling --log-debug
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
None

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: feature
summary: Bump werf version to v2.78.1-dk.1 and add build-report-operations
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
