### PR TITLE
[user-authz] Add the module to the generated alerts index

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -7321,3 +7321,4 @@ modules-having-alerts:
     - terraform-manager
     - upmeter
     - user-authn
+    - user-authz


### PR DESCRIPTION
## Description

`docs/documentation/_data/deckhouse-alerts.yml` is generated by `tools/` (`go generate`, the
`alert_templates` runner) and carries, besides the alert bodies, a list of every module that has
alerts at all. On this branch `user-authz` gained its first ones — `D8UserAuthzReleaseSlow` and
`D8UserAuthzRenderSlow`, from `modules/140-user-authz/monitoring/prometheus-rules/release-duration.yaml`
— but the module is not in that list, so the generated file no longer matches its sources.

This adds the missing entry. It is one line, and it is exactly what the generator writes: with this
change the file's blob hash is `5159644aea`, which is the post-image the failing job reported.

No behaviour changes: the file is data for the documentation site.

## Why do we need it, and what problem does it solve?

Without it the build of this branch fails. `Build FE` → `Check generated code` runs
`git diff --exit-code` after `go generate` and finds the missing line:

```text
@@ -7321,3 +7321,4 @@ modules-having-alerts:
     - upmeter
     - user-authn
+    - user-authz
```

The alerts reference of the documentation is also incomplete until then: the two alerts are
described in the file, but the module is absent from the index that the site uses to link them.

## Why do we need it in the patch release (if we do)?

It only applies here. On `main` and `release-1.77` the module was already in the list, because it
already had other alerts there, so nothing regenerates differently.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Verified by regenerating: a worktree at the branch point, `cd tools && go generate`, and the only
change the generator makes to the tree is this line.

## Changelog entries

No entry: generated data for the documentation site, with no user-visible change.
