### PR TITLE
[service-with-healthchecks] Fix EndpointSlices never restored after a target pod is replaced.

### DIFF
--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent.go
@@ -41,6 +41,14 @@ const (
 	endpointServiceNameLabelKey = "kubernetes.io/service-name"
 	endpointControllerLabelKey  = "endpointslice.kubernetes.io/managed-by"
 	controllerName              = "servicewithhealthchecks"
+
+	// resyncPeriod bounds how long a ServiceWithHealthchecks may stay out of sync with the
+	// pods on this node. New target pods are learned from watch events only, and once the
+	// last target is gone there is no probe result left to wake the reconciliation up
+	// either — so a single missed event would otherwise keep the EndpointSlice empty until
+	// the cache resync (10h by default) or an agent restart. The resync is read-only in the
+	// steady state: neither the status nor the EndpointSlice is written when nothing changed.
+	resyncPeriod = time.Minute
 )
 
 // ServiceWithHealthchecksReconciler reconciles a ServiceWithHealthchecks object
@@ -146,14 +154,14 @@ func (r *ServiceWithHealthchecksReconciler) Reconcile(ctx context.Context, req c
 	kubernetes.SortConditions(serviceWithHC.Status.Conditions)
 
 	if reflect.DeepEqual(serviceWithHC.Status, updatedServiceWithHC.Status) {
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	}
 
 	err = r.Status().Patch(ctx, updatedServiceWithHC, patch)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to patch status of ServiceWithHealthchecks: %w", err)
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -252,19 +260,26 @@ func (r *ServiceWithHealthchecksReconciler) getExposedServiceWithHCForPod(ctx co
 	// iterate over saved services specifications and check if it matches pod labels
 	r.servicesWithHealthchecks.Range(func(key, value any) bool {
 		svcWithHCName := key.(types.NamespacedName)
-		svcWithHCSpec := value.(networkv1alpha1.ServiceWithHealthchecksSpec)
-		podsLabels := pod.GetLabels()
 
-		if labels.ValidatedSetSelector(svcWithHCSpec.Selector).Matches(labels.Set(podsLabels)) {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      svcWithHCName.Name,
-					Namespace: svcWithHCName.Namespace,
-				},
-			})
+		// A ServiceWithHealthchecks only ever selects pods of its own namespace, see the List
+		// call in Reconcile. Checked before the spec is read out of the interface, so that an
+		// entry of another namespace costs a string comparison instead of a struct copy.
+		if svcWithHCName.Namespace != pod.GetNamespace() {
 			return true
 		}
-		return false
+
+		svcWithHCSpec := value.(networkv1alpha1.ServiceWithHealthchecksSpec)
+		if labels.ValidatedSetSelector(svcWithHCSpec.Selector).Matches(labels.Set(pod.GetLabels())) {
+			requests = append(requests, reconcile.Request{NamespacedName: svcWithHCName})
+		}
+
+		// Every stored ServiceWithHealthchecks has to be examined, so the iteration is never
+		// stopped: sync.Map.Range treats a false return as "stop", and stopping at the first
+		// non-matching entry silently drops the event for all the entries behind it. Range
+		// order is randomized, so a pod of the Nth ServiceWithHealthchecks would only be
+		// noticed when it happens to be visited first — and a missed pod creation leaves the
+		// EndpointSlice empty until something else triggers a reconciliation.
+		return true
 	})
 	return requests
 }

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent_test.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/agent/agent_test.go
@@ -6,13 +6,19 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package agent
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 
@@ -526,4 +532,147 @@ func TestEndpointsAreEqualKeepsArgumentsIntact(t *testing.T) {
 
 func ptrTo[T any](v T) *T {
 	return &v
+}
+
+// lbSelectorKey mimics the label a DVP cloud provider puts on the load balancer targets.
+const lbSelectorKey = "dvp.deckhouse.io/aabdc1ef544fa4272ac805a88ffa698b"
+
+func specWithSelector(selector map[string]string) networkv1alpha1.ServiceWithHealthchecksSpec {
+	return networkv1alpha1.ServiceWithHealthchecksSpec{
+		ServiceSpec: corev1.ServiceSpec{Selector: selector},
+	}
+}
+
+func newTargetPod(name string) corev1.Pod {
+	pod := newPod(name, corev1.PodRunning, true, testPodIP)
+	pod.Spec.NodeName = testNodeName
+	pod.Labels = map[string]string{lbSelectorKey: "loadbalancer"}
+	return pod
+}
+
+// storeNonMatchingSWHs fills the internal map with unrelated ServiceWithHealthchecks, as a
+// namespace hosting several load balancers does.
+func storeNonMatchingSWHs(r *ServiceWithHealthchecksReconciler, count int) {
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("other-%d", i)
+		r.servicesWithHealthchecks.Store(
+			types.NamespacedName{Namespace: testNamespace, Name: name},
+			specWithSelector(map[string]string{"dvp.deckhouse.io/" + name: "loadbalancer"}),
+		)
+	}
+}
+
+func TestGetExposedServiceWithHCForPodEnqueuesMatchBehindNonMatchingEntries(t *testing.T) {
+	r := newTestReconciler()
+	matching := types.NamespacedName{Namespace: testNamespace, Name: testSWHName}
+	r.servicesWithHealthchecks.Store(matching, specWithSelector(map[string]string{lbSelectorKey: "loadbalancer"}))
+	storeNonMatchingSWHs(r, 9)
+
+	pod := newTargetPod("virt-launcher-worker-rvtjp-dz8lg")
+
+	// sync.Map.Range visits the entries in a randomized order, so a handler that stops the
+	// iteration at the first non-matching entry loses the request only part of the time.
+	// Repeating makes the failure certain instead of flaky.
+	for i := 0; i < 100; i++ {
+		requests := r.getExposedServiceWithHCForPod(context.Background(), &pod)
+		if len(requests) != 1 || requests[0].NamespacedName != matching {
+			t.Fatalf("run %d: got %v, want exactly one request for %s", i, requests, matching)
+		}
+	}
+}
+
+func TestGetExposedServiceWithHCForPodEnqueuesEveryMatch(t *testing.T) {
+	r := newTestReconciler()
+	first := types.NamespacedName{Namespace: testNamespace, Name: testSWHName}
+	second := types.NamespacedName{Namespace: testNamespace, Name: testSWHName + "-https"}
+	r.servicesWithHealthchecks.Store(first, specWithSelector(map[string]string{lbSelectorKey: "loadbalancer"}))
+	r.servicesWithHealthchecks.Store(second, specWithSelector(map[string]string{lbSelectorKey: "loadbalancer"}))
+	storeNonMatchingSWHs(r, 8)
+
+	pod := newTargetPod("virt-launcher-worker-rvtjp-dz8lg")
+
+	for i := 0; i < 100; i++ {
+		requests := r.getExposedServiceWithHCForPod(context.Background(), &pod)
+		if len(requests) != 2 {
+			t.Fatalf("run %d: got %v, want requests for both %s and %s", i, requests, first, second)
+		}
+		got := map[types.NamespacedName]bool{
+			requests[0].NamespacedName: true,
+			requests[1].NamespacedName: true,
+		}
+		if !got[first] || !got[second] {
+			t.Fatalf("run %d: got %v, want requests for both %s and %s", i, requests, first, second)
+		}
+	}
+}
+
+func TestGetExposedServiceWithHCForPodIgnoresForeignPods(t *testing.T) {
+	r := newTestReconciler()
+	r.servicesWithHealthchecks.Store(
+		types.NamespacedName{Namespace: testNamespace, Name: testSWHName},
+		specWithSelector(map[string]string{lbSelectorKey: "loadbalancer"}),
+	)
+
+	otherNode := newTargetPod("pod-on-another-hypervisor")
+	otherNode.Spec.NodeName = "hv-07"
+
+	otherNamespace := newTargetPod("pod-of-another-team")
+	otherNamespace.Namespace = "team-d8-other"
+
+	notAPod := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: testSWHName, Namespace: testNamespace}}
+
+	tests := []struct {
+		name   string
+		object client.Object
+	}{
+		{"pod on another node", &otherNode},
+		{"pod in another namespace", &otherNamespace},
+		{"not a pod", notAPod},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if requests := r.getExposedServiceWithHCForPod(context.Background(), test.object); len(requests) != 0 {
+				t.Errorf("got %v, want no requests", requests)
+			}
+		})
+	}
+}
+
+func TestReconcileKeepsRequeueingItself(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, addToScheme := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme, discoveryv1.AddToScheme, networkv1alpha1.AddToScheme,
+	} {
+		if err := addToScheme(scheme); err != nil {
+			t.Fatalf("failed to build scheme: %v", err)
+		}
+	}
+
+	swh := newTestSWH()
+	swh.Spec.Selector = map[string]string{lbSelectorKey: "loadbalancer"}
+
+	r := newTestReconciler()
+	r.Client = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&swh).
+		WithStatusSubresource(&networkv1alpha1.ServiceWithHealthchecks{}).
+		WithIndex(&corev1.Pod{}, "spec.nodeName", func(object client.Object) []string {
+			return []string{object.(*corev1.Pod).Spec.NodeName}
+		}).
+		Build()
+
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testSWHName}}
+
+	// The second pass leaves the status untouched and must still requeue: an agent that stops
+	// requeueing once the state is settled has no way back if a watch event is ever missed.
+	for _, pass := range []string{"first", "second"} {
+		result, err := r.Reconcile(context.Background(), request)
+		if err != nil {
+			t.Fatalf("%s reconcile failed: %v", pass, err)
+		}
+		if result.RequeueAfter != resyncPeriod {
+			t.Errorf("%s reconcile: RequeueAfter = %v, want %v", pass, result.RequeueAfter, resyncPeriod)
+		}
+	}
 }

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -30,6 +31,13 @@ import (
 const (
 	endpointControllerLabelKey = "endpointslice.kubernetes.io/managed-by"
 	controllerName             = "servicewithhealthchecks"
+
+	// resyncPeriod bounds how long an EndpointSlice of a node that no longer exists may stay
+	// published. clearNotUsedEPS runs on reconciliation only, and nothing watches Nodes, so
+	// without the resync a removed node would keep a dead endpoint in the child Service until
+	// the next unrelated event on the object. It is longer than the agent's own resync because
+	// this only performs cleanup, and each pass lists Nodes cluster-wide from the cache.
+	resyncPeriod = 5 * time.Minute
 )
 
 // ServiceWithHealthchecksReconciler reconciles a ServiceWithHealthchecks object
@@ -143,13 +151,13 @@ func (r *ServiceWithHealthchecksReconciler) Reconcile(ctx context.Context, req c
 	kubernetes.SortConditions(originalServiceWithHC.Status.Conditions)
 
 	if reflect.DeepEqual(originalServiceWithHC.Status, serviceWithHC.Status) {
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 	}
 
 	if err := r.Status().Patch(ctx, serviceWithHC, patch); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update ServiceWithHealthchecks Status: %w", err)
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: resyncPeriod}, nil
 }
 
 func createStatusConditionForService(err error, svcName string) metav1.Condition {

--- a/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller_test.go
+++ b/ee/modules/610-service-with-healthchecks/images/artifact/internal/controller/controller_test.go
@@ -254,3 +254,33 @@ func TestIsMetadataForServiceEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileKeepsRequeueingItself(t *testing.T) {
+	scheme := newTestScheme(t)
+	swh := newTestSWH(nil, nil)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(swh).
+		WithStatusSubresource(&networkv1alpha1.ServiceWithHealthchecks{}).
+		Build()
+
+	reconciler := &ServiceWithHealthchecksReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		Logger: log.NewNop(),
+	}
+	request := ctrl.Request{NamespacedName: types.NamespacedName{Name: testName, Namespace: testNamespace}}
+
+	// The second pass changes nothing and must still requeue: clearNotUsedEPS only runs on
+	// reconciliation, and nothing watches Nodes, so a controller that stops requeueing keeps
+	// the EndpointSlices of removed nodes published.
+	for _, pass := range []string{"first", "second"} {
+		result, err := reconciler.Reconcile(context.Background(), request)
+		if err != nil {
+			t.Fatalf("%s reconcile failed: %v", pass, err)
+		}
+		if result.RequeueAfter != resyncPeriod {
+			t.Errorf("%s reconcile: RequeueAfter = %v, want %v", pass, result.RequeueAfter, resyncPeriod)
+		}
+	}
+}


### PR DESCRIPTION
## Description

The agent's pod watch handler stopped iterating over the stored `ServiceWithHealthchecks` at the
first one whose selector did not match the pod — `sync.Map.Range` treats a `false` return as "stop".
Range order is randomized, so a pod event reached the right object only when it happened to be
visited first. The handler now examines every entry.

Both reconcilers also requeue themselves periodically (1 min in the agent, 5 in the controller), so
no missed event can pin the data plane. The resync writes nothing while the state is settled, so it
does not reintroduce the status storm fixed in #19455. **The controller and agent are restarted on
update**; affected load balancers recover on their own once the new agent starts.

## Why do we need it, and what problem does it solve?

Replacing a target pod — a worker VM being recreated or migrated, say — took the load balancer down
for good: the child Service kept its external IP but lost every endpoint. It could not recover by
itself, because with no target left there is no probe result to wake the reconciliation up either.
Outages lasted hours and hit several objects at once.

The bug is as old as the module but was unreachable: the status storm reconciled everything many
times per second, so a new pod was always picked up regardless. Fixing the storm in #19455 removed
that accidental resync, and the module has none of its own.

## Why do we need it in the patch release (if we do)?

The storm fix shipped in v1.76.13, so every installation on v1.76.13+ is exposed: any target pod
replacement can silently take an external load balancer down. This has already caused production
outages. The change is small, unit-tested, and limited to this module.


## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: service-with-healthchecks
type: fix
summary: Fixed a load balancer losing all its endpoints for good after a target pod was replaced.
impact: |
  The `service-with-healthchecks` controller and agent are restarted.
  A `ServiceWithHealthchecks` that was left in `NotAllEndpointsAreReady` with no EndpointSlice
  recovers automatically once the updated agent starts, no manual action is needed.
impact_level: default
```
