### PR TITLE
[node-manager] Format imports in force machine deployment hook

### DIFF
--- a/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership.go
+++ b/modules/040-node-manager/hooks/force_machine_deployment_replicas_ownership.go
@@ -68,10 +68,10 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/ptr"
 
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/module-sdk/pkg"
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/capi/v1beta1"
 	"github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/mcm/v1alpha1"
 )


### PR DESCRIPTION
## Description

Fix import grouping in the node-manager hook to comply with the gci formatter.
This change only affects code formatting and does not change runtime behavior or restart any cluster components.

## Why do we need it, and what problem does it solve?

The golangci-lint check fails because force_machine_deployment_replicas_ownership.go does not follow the configured gci import grouping rules.
The change fixes the import order so the file passes lint checks.

## Why do we need it in the patch release (if we do)?

The issue causes the golangci-lint check to fail in release-1.76.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: chore
summary: Fix import formatting in the force machine deployment replicas ownership hook.
impact_level: low
```