### PR TITLE
[deckhouse] add x-deckhouse-ui-group type

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types.go
@@ -118,6 +118,11 @@ type OpenAPIV3Schema struct {
 	// matching resource names from the application's namespace.
 	// +optional
 	XUIResourceName *UIResourceNameSelector `json:"x-deckhouse-ui-resource-name,omitempty"`
+
+	// x-deckhouse-ui-group renders a settings field inside the named root-level group
+	// of the web console form; the field's path in settings stays unchanged.
+	// +optional
+	XUIGroup string `json:"x-deckhouse-ui-group,omitempty"`
 }
 
 // OpenAPIV3SchemaOrArray represents a value that can either be an OpenAPIV3Schema

--- a/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/openapi/types_test.go
@@ -183,6 +183,7 @@ func TestMarshalRoundtrip_xDeckhouseExtensions(t *testing.T) {
 				Type:        StringOrArray{"integer"},
 				Default:     jsonPtr("1"),
 				XUIAdvanced: true,
+				XUIGroup:    "toggles",
 				XUIOrder:    int64Ptr(2),
 			},
 			"secretName": {
@@ -237,6 +238,9 @@ func TestMarshalRoundtrip_xDeckhouseExtensions(t *testing.T) {
 	}
 	if rep.XUIOrder == nil || *rep.XUIOrder != 2 {
 		t.Errorf("x-deckhouse-ui-order mismatch")
+	}
+	if rep.XUIGroup != "toggles" {
+		t.Errorf("x-deckhouse-ui-group: got %q, want toggles", rep.XUIGroup)
 	}
 	if len(restored.XValidations) != 1 || restored.XValidations[0].Expression != "self.storageClass != ''" {
 		t.Errorf("x-deckhouse-validations: got %+v", restored.XValidations)


### PR DESCRIPTION
## Description
Adds a new vendor extension `x-deckhouse-ui-group` (`XUIGroup` field) to the `OpenAPIV3Schema` type in `deckhouse-controller/pkg/apis/deckhouse.io/openapi`.

The extension lets a module author render a settings field inside a named root-level group of the web console form. It only affects how the field is grouped in the UI; the field's path in settings stays unchanged.

The marshal/unmarshal roundtrip test is extended to cover the new extension. This is a schema/type-only change consumed by the web console UI — it does not restart or otherwise influence critical cluster components (control-plane, ingress-controllers, Prometheus, etc.).

## Why do we need it, and what problem does it solve?
As the number of settings in a module grows, a flat form in the web console becomes hard to navigate. Module authors need a declarative way, right in the settings schema, to organize related fields into named groups without changing the underlying settings structure. `x-deckhouse-ui-group` provides this: fields are visually grouped in the form while their paths in settings remain the same.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: Add the `x-deckhouse-ui-group` OpenAPI extension to render a settings field inside a named group in the web console form.
```