### PR TITLE
[ci] Skip crd-enricher tests when the module is absent

### DIFF
--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -5,7 +5,7 @@
 {!{ define "unit_run_args" }!}
 # <template: unit_run_args>
 setup_cmd: 'pm install git'
-args: 'sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules test-crd-enricher"'
+args: 'sh -c "git config --global --add safe.directory /deckhouse && { set -e; make tests-controller tests-modules; if [ -f pkg/crd-enricher/go.mod ]; then make test-crd-enricher; fi; }"'
 docker_options: '-w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg'
 exec_options: '-u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse'
 # </template: unit_run_args>

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -4206,7 +4206,7 @@ jobs:
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           CONTAINER_ID=$(docker run -d -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sleep infinity)
           docker exec -u 0:0 ${CONTAINER_ID} pm install git
-          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules test-crd-enricher"
+          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && { set -e; make tests-controller tests-modules; if [ -f pkg/crd-enricher/go.mod ]; then make test-crd-enricher; fi; }"
           docker rm -f ${CONTAINER_ID}
     # </template: tests_before_build_template>
 

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -1577,7 +1577,7 @@ jobs:
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           CONTAINER_ID=$(docker run -d -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sleep infinity)
           docker exec -u 0:0 ${CONTAINER_ID} pm install git
-          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules test-crd-enricher"
+          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && { set -e; make tests-controller tests-modules; if [ -f pkg/crd-enricher/go.mod ]; then make test-crd-enricher; fi; }"
           docker rm -f ${CONTAINER_ID}
     # </template: tests_before_build_template>
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3587,7 +3587,7 @@ jobs:
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           CONTAINER_ID=$(docker run -d -w /deckhouse -v ${{github.workspace}}:/deckhouse --tmpfs /tmp:mode=1777,exec -e HOME=/tmp -e "TERM=xterm-256color" -v ~/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sleep infinity)
           docker exec -u 0:0 ${CONTAINER_ID} pm install git
-          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && make tests-controller tests-modules test-crd-enricher"
+          docker exec -u $(id -u):$(id -g) -e HOME=/tmp -w /deckhouse ${CONTAINER_ID} sh -c "git config --global --add safe.directory /deckhouse && { set -e; make tests-controller tests-modules; if [ -f pkg/crd-enricher/go.mod ]; then make test-crd-enricher; fi; }"
           docker rm -f ${CONTAINER_ID}
     # </template: tests_before_build_template>
 


### PR DESCRIPTION
## Description

Run `test-crd-enricher` only when `pkg/crd-enricher/go.mod` exists. Keep `tests-controller` and `tests-modules` mandatory, with `set -e` to stop on test failures.

Update `.github/ci_templates/tests.yml` and regenerate workflows using `make render-workflow`.

## Why do we need it, and what problem does it solve?

CI workflows from `main` can run against branches without the crd-enricher module. The unconditional test invocation causes CI to fail on these branches.

This fixes the CI failure affecting #22983. The change must be merged into `main`, followed by a new CI run.

## Why do we need it in the patch release (if we do)?

Not necessarily. The fix is needed in the CI workflow on `main`.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Validation: workflow regeneration and YAML validation passed. Shell checks confirmed correct behavior with and without the module, including propagation of test failures.

## Changelog entries

```changes
section: ci
type: fix
summary: Skip crd-enricher tests when the Go module is absent in the checked-out branch.
impact_level: low
```