### PR TITLE
[descheduler]: add safe to evict on storage class

### DIFF
--- a/modules/400-descheduler/crds/deschedulers.yaml
+++ b/modules/400-descheduler/crds/deschedulers.yaml
@@ -490,6 +490,29 @@ spec:
                   type: boolean
                   default: false
                   description: Allows Pods using local storage to be evicted.
+                protectedStorageClasses:
+                  type: array
+                  description: |-
+                    A list of StorageClass names whose Pods must not be evicted.
+
+                    If a Pod refers to a PersistentVolumeClaim provisioned by one of the listed StorageClasses,
+                    the descheduler will never evict such a Pod.
+
+                    Note the following:
+                    - An empty list (or an omitted parameter) keeps the current behavior: Pods with PVCs are evicted as usual.
+                    - A Pod whose PersistentVolumeClaim cannot be resolved (the PVC is missing or has an empty `storageClassName`)
+                      is considered protected as well.
+                  items:
+                    type: string
+                    description: A StorageClass name.
+                    minLength: 1
+                    maxLength: 253
+                    pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+                  minItems: 1
+                  uniqueItems: true
+                  x-doc-examples:
+                    - - local-path
+                      - ceph-rbd
                 strategies:
                   type: object
                   description: Settings of strategies for the Descheduler instances.

--- a/modules/400-descheduler/crds/doc-ru-deschedulers.yaml
+++ b/modules/400-descheduler/crds/doc-ru-deschedulers.yaml
@@ -252,6 +252,19 @@ spec:
                       description: Значение класса приоритета.
                 evictLocalStoragePods:
                   description: Позволяет вытеснять поды, использующие локальное хранилище.
+                protectedStorageClasses:
+                  description: |-
+                    Список имён StorageClass, поды которых запрещено вытеснять.
+
+                    Если под использует PersistentVolumeClaim, созданный одним из перечисленных StorageClass,
+                    descheduler никогда не будет вытеснять такой под.
+
+                    Обратите внимание:
+                    - Пустой список (или отсутствие параметра) сохраняет текущее поведение: поды с PVC вытесняются как обычно.
+                    - Под, для которого не удалось определить PersistentVolumeClaim (PVC отсутствует или у него пустой `storageClassName`),
+                      также считается защищённым.
+                  items:
+                    description: Имя StorageClass.
                 strategies:
                   description:
                     Настройки стратегий данного экземпляра ресурса Descheduler.

--- a/modules/400-descheduler/docs/EXAMPLES.md
+++ b/modules/400-descheduler/docs/EXAMPLES.md
@@ -61,3 +61,32 @@ spec:
         cpu: 50
         memory: 50
 ```
+
+## Protecting pods by StorageClass
+
+Use the [`protectedStorageClasses`](cr.html#descheduler-v1alpha2-spec-protectedstorageclasses) parameter to forbid evicting pods that use PersistentVolumeClaims provisioned by specific StorageClasses. This is useful for storage that is bound to a node (for example, `local-path`), where evicting a pod either loses the data locality or leaves the pod unschedulable.
+
+```yaml
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: Descheduler
+metadata:
+  name: protect-local-storage
+spec:
+  protectedStorageClasses:
+    - local-path
+  strategies:
+    lowNodeUtilization:
+      enabled: true
+      thresholds:
+        cpu: 20
+      targetThresholds:
+        cpu: 50
+```
+
+With this configuration, the descheduler still rebalances every other pod, but a pod with a PersistentVolumeClaim from the `local-path` StorageClass is never evicted.
+
+Keep the following in mind:
+
+- If the parameter is omitted or empty, the behavior does not change: pods with PersistentVolumeClaims are evicted as usual.
+- A pod is also considered protected when its PersistentVolumeClaim cannot be resolved, that is, the PVC does not exist or its `storageClassName` is empty. Such pods are never evicted while the parameter is set.

--- a/modules/400-descheduler/docs/EXAMPLES_RU.md
+++ b/modules/400-descheduler/docs/EXAMPLES_RU.md
@@ -59,3 +59,32 @@ spec:
         cpu: 50
         memory: 50
 ```
+
+## Защита подов по StorageClass
+
+Параметр [`protectedStorageClasses`](cr.html#descheduler-v1alpha2-spec-protectedstorageclasses) запрещает вытеснять поды, использующие PersistentVolumeClaim из указанных StorageClass. Это полезно для хранилищ, привязанных к узлу (например, `local-path`), где вытеснение пода либо ломает локальность данных, либо оставляет под без возможности запуска.
+
+```yaml
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: Descheduler
+metadata:
+  name: protect-local-storage
+spec:
+  protectedStorageClasses:
+    - local-path
+  strategies:
+    lowNodeUtilization:
+      enabled: true
+      thresholds:
+        cpu: 20
+      targetThresholds:
+        cpu: 50
+```
+
+С такой конфигурацией descheduler продолжит перераспределять остальные поды, но под с PersistentVolumeClaim из StorageClass `local-path` вытеснен не будет.
+
+Обратите внимание:
+
+- Если параметр не указан или список пуст, поведение не меняется: поды с PersistentVolumeClaim вытесняются как обычно.
+- Под также считается защищённым, если его PersistentVolumeClaim не удалось определить, то есть PVC отсутствует или у него пустой `storageClassName`. Такие поды не вытесняются, пока параметр задан.

--- a/modules/400-descheduler/e2e/descheduler/README.md
+++ b/modules/400-descheduler/e2e/descheduler/README.md
@@ -96,6 +96,8 @@ descheduler/
     │   └── ...
     ├── statefulset-single-replica-eviction/
     │   └── ...
+    ├── protected-storage-class-blocks-eviction/
+    │   └── ...
     └── descheduler-minreplicas-not-supported/
         └── ...
 ```
@@ -114,6 +116,7 @@ Per-scenario details (steps, manifests, expected outcomes): `tests/<name>/README
 | `task statefulset-pdb-blocks-eviction:run` | `tests/statefulset-pdb-blocks-eviction/` | StatefulSet + PDB `maxUnavailable: 0`: every eviction is blocked, pods stay in place |
 | `task statefulset-pdb-allows-one-disruption:run` | `tests/statefulset-pdb-allows-one-disruption/` | StatefulSet + PDB `maxUnavailable: 1`: evictions are serialized, StatefulSet stays available |
 | `task statefulset-single-replica-eviction:run` | `tests/statefulset-single-replica-eviction/` | Single-replica StatefulSet is evicted — no `minReplicas` protection exists in Deckhouse |
+| `task protected-storage-class-blocks-eviction:run` | `tests/protected-storage-class-blocks-eviction/` | `spec.protectedStorageClasses` blocks eviction of a pod using a PVC from the listed StorageClass; dropping the protection evicts the same pod |
 | `task descheduler-minreplicas-not-supported:run` | `tests/descheduler-minreplicas-not-supported/` | `spec.minReplicas` cannot be persisted in the CR; manual ConfigMap edits are overwritten |
 
 ## Running Tests

--- a/modules/400-descheduler/e2e/descheduler/Taskfile.yaml
+++ b/modules/400-descheduler/e2e/descheduler/Taskfile.yaml
@@ -16,6 +16,9 @@ includes:
   low-node-utilization:
     taskfile: ./tests/low-node-utilization/Taskfile.yml
     dir: ./tests/low-node-utilization
+  protected-storage-class-blocks-eviction:
+    taskfile: ./tests/protected-storage-class-blocks-eviction/Taskfile.yml
+    dir: ./tests/protected-storage-class-blocks-eviction
   statefulset-pdb-allows-one-disruption:
     taskfile: ./tests/statefulset-pdb-allows-one-disruption/Taskfile.yml
     dir: ./tests/statefulset-pdb-allows-one-disruption
@@ -38,6 +41,7 @@ tasks:
       - task: exclude-namespaces-from-processing:run
       - task: high-node-utilization:run
       - task: low-node-utilization:run
+      - task: protected-storage-class-blocks-eviction:run
       - task: statefulset-pdb-allows-one-disruption:run
       - task: statefulset-pdb-blocks-eviction:run
       - task: statefulset-remove-duplicates:run
@@ -51,6 +55,7 @@ tasks:
       - task: exclude-namespaces-from-processing:dry-run
       - task: high-node-utilization:dry-run
       - task: low-node-utilization:dry-run
+      - task: protected-storage-class-blocks-eviction:dry-run
       - task: statefulset-pdb-allows-one-disruption:dry-run
       - task: statefulset-pdb-blocks-eviction:dry-run
       - task: statefulset-remove-duplicates:dry-run

--- a/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/README.md
+++ b/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/README.md
@@ -1,0 +1,96 @@
+# Descheduler — protected StorageClass blocks eviction
+
+## Summary
+
+A [Kyverno Chainsaw](https://kyverno.github.io/chainsaw/) e2e test that validates `spec.protectedStorageClasses`: a pod using a PersistentVolumeClaim from a listed StorageClass is never evicted, while the same pod is evicted once the StorageClass is removed from the list.
+
+**What it does:** Creates a single-replica StatefulSet with a `volumeClaimTemplate` backed by the cluster's default StorageClass, then force-places a conflict pod on the same node so the StatefulSet pod violates its own required `podAntiAffinity` — the same deterministic eviction trigger the single-replica test uses. With `protectedStorageClasses` set, a full descheduling cycle must leave the pod untouched. The CR is then updated to drop the protection, and the very same pod must be evicted.
+
+## Prerequisites
+
+- Multi-node Kubernetes cluster (at least **2** schedulable worker nodes)
+- Exactly one **default StorageClass** able to provision a 1Gi `ReadWriteOnce` volume
+- Descheduler pre-installed in the `d8-descheduler` namespace
+- Deckhouse **ClusterAdmin**-level rights to create `Descheduler` CRs (a plain `kubernetes-admin` identity is denied)
+- Chainsaw CLI installed. See `../../README.md` for instructions.
+
+## Test Steps
+
+| Step | Name | Description |
+|------|------|-------------|
+| 1 | `assert-module-installed` | Asserts the `deschedulers.deckhouse.io` CRD exists |
+| 2 | `check-minimum-nodes` | Verifies ≥2 eligible worker nodes (so `nodeFit` would allow eviction and only the protection stands in the way) |
+| 3 | `check-default-storage-class` | Verifies exactly one default StorageClass exists and binds it to `$storageClass` |
+| 4 | `create-statefulset` | Creates a 1-replica StatefulSet with a `volumeClaimTemplate` on `$storageClass` |
+| 5 | `wait-statefulset-ready` | Waits until the pod is Running, the PVC is `Bound` and the STS is 1/1 ready |
+| 6 | `create-conflict-pod` | Captures the pod's node, force-places `conflict-pod` there via `spec.nodeName`, making the StatefulSet pod violate its anti-affinity |
+| 7 | `verify-protected-pod-is-not-evicted` | Applies the CR with `protectedStorageClasses`, asserts the rendered policy carries `podProtections`/`PodsWithPVC`/the StorageClass name, waits for the rollout, captures the pod UID, sleeps one cycle (300s), then asserts: no eviction event, identical UID, pod unmoved |
+| 8 | `verify-pod-is-evicted-without-protection` | Captures the UID, updates the same CR without `protectedStorageClasses`, asserts the policy lost `PodsWithPVC`, waits for the rollout, then asserts the pod **was** evicted (new UID) and an eviction event exists |
+
+**Cleanup:** Step 8 cleanup deletes the Descheduler CR. The test namespace (StatefulSet, PVC, conflict pod) is auto-deleted by Chainsaw.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `manifests/sts-with-pvc.yaml` | 1-replica StatefulSet with a `volumeClaimTemplate` and a required `podAntiAffinity` against the conflict label |
+| `manifests/conflict-pod.yaml` | Bare pod carrying the repelled label, force-placed via `spec.nodeName` |
+| `manifests/descheduler-cr-protected.yaml` | Descheduler CR with `protectedStorageClasses` and `removePodsViolatingInterPodAntiAffinity` |
+| `manifests/descheduler-cr-unprotected.yaml` | Same CR without `protectedStorageClasses` (the control) |
+| `../common/asserts/assert-descheduler-rollout-complete.yaml` | Shared assert: rollout finished and the pod runs the current policy |
+
+## Why This Is a Negative Test (and how it stays honest)
+
+1. **The pod is genuinely evictable.** The eviction trigger is a real, required anti-affinity violation, the live pod spec carries no node constraint (it is placed by the scheduler, never pinned via `nodeName` or `nodeSelector`), and ≥2 worker nodes are asserted — so `nodeFit` would allow the eviction.
+2. **The new policy is proven live before checking.** `assert-descheduler-rollout-complete.yaml` asserts the running descheduler pod carries the current `checksum/config`, so a full cycle really ran against the new policy during the 300s sleep.
+3. **A control phase proves causality.** Step 8 drops only `protectedStorageClasses` from the same CR, against the same pod and the same violation, and requires the eviction to happen. Without it, step 7 could pass for any unrelated reason.
+4. **The rendered policy is asserted, not just the outcome.** The `PodsWithPVC` key under `podProtections.config` is matched by name upstream and an unknown key is silently ignored, which would protect *every* pod with a PVC instead of the listed StorageClasses. Step 7 asserts the ConfigMap actually contains `podProtections`, `PodsWithPVC` and the StorageClass name.
+
+## Policy Config
+
+- `protectedStorageClasses: [<default StorageClass>]` renders as `podProtections.extraEnabled: ["PodsWithPVC"]` plus `podProtections.config.PodsWithPVC.protectedStorageClasses`.
+- In that branch the deprecated `evictLocalStoragePods` / `evictSystemCriticalPods` / `ignorePvcPods` / `evictFailedBarePods` flags are not rendered at all: upstream `DefaultEvictor` validation rejects a policy that mixes them with `podProtections`, and the descheduler would refuse to start.
+
+## Running
+
+```bash
+# From the e2e directory
+task protected-storage-class-blocks-eviction:run
+
+# Or directly
+chainsaw test --test-dir ./tests/protected-storage-class-blocks-eviction/
+```
+
+This test runs two descheduling phases (~10–12 min) because of the deliberate 300s sleep plus two descheduler rollouts.
+
+## Pass/Fail Criteria
+
+- **Pass:** with the protection in place the pod keeps its UID and node and no eviction event appears; after the protection is dropped the pod is recreated with a new UID and an eviction event is recorded.
+- **Fail:** the protected pod is evicted, the control phase does not evict (the test would otherwise be vacuous), or the rendered policy does not carry `podProtections`/`PodsWithPVC`.
+
+## Troubleshooting
+
+### The protected pod WAS evicted
+
+Check that the rendered policy really carries the protection and that the PVC resolves to the expected StorageClass:
+
+```bash
+kubectl -n d8-descheduler get cm descheduler-policy -o jsonpath='{.data.policy\.yaml}'
+kubectl -n <test-namespace> get pvc data-test-sts-pvc-0 -o jsonpath='{.spec.storageClassName}'
+```
+
+### The control phase does not evict
+
+The pod is protected by something else than the StorageClass — most often `nodeFit` (no second node accepts the pod, which happens when the volume is node-local and the replacement can only return to the same node). Check the descheduler log:
+
+```bash
+kubectl -n d8-descheduler logs -l app=descheduler -c descheduler | grep -iE "nodeFit|does not fit|protected"
+```
+
+### `create deschedulers ... is forbidden`
+
+```bash
+kubectl auth can-i create deschedulers.deckhouse.io
+```
+
+Run under a Deckhouse ClusterAdmin-level identity (see `../../README.md`).

--- a/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/Taskfile.yml
+++ b/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/Taskfile.yml
@@ -1,0 +1,38 @@
+version: "3"
+
+vars:
+  CONFIG: ../../chainsaw-config.yaml
+
+tasks:
+  run:
+    desc: Run e2e test with JUNIT report
+    cmds:
+      - mkdir -p ./reports
+      - chainsaw test --test-dir . --config {{.CONFIG}} --parallel 1 --report-format JUNIT-STEP --report-path ./reports/
+
+  run:quiet:
+    desc: Run e2e test with suppressed output (only errors, failures, summary)
+    cmds:
+      - mkdir -p ./reports
+      - chainsaw test --test-dir . --config {{.CONFIG}} --parallel 1 --report-format JUNIT-STEP --report-path ./reports/ --quiet
+
+  lint:test:
+    desc: Validate test YAML against the chainsaw schema
+    cmds:
+      - chainsaw lint test -f chainsaw-test.yaml
+
+  lint:configuration:
+    desc: Validate configuration YAML against the chainsaw schema
+    cmds:
+      - chainsaw lint configuration -f {{.CONFIG}}
+
+  dry-run:
+    desc: Validate test YAML without a cluster
+    cmds:
+      - chainsaw test --test-dir . --config {{.CONFIG}} --no-cluster
+
+  run:debug:
+    desc: Run test with pause on failure and fail-fast
+    cmds:
+      - mkdir -p ./reports
+      - chainsaw test --test-dir . --config {{.CONFIG}} --parallel 1 --report-format JUNIT-STEP --report-path ./reports/ --pause-on-failure --fail-fast

--- a/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/chainsaw-test.yaml
+++ b/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/chainsaw-test.yaml
@@ -1,0 +1,332 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: descheduler-protected-storage-class-blocks-eviction
+spec:
+  description: >-
+    spec.protectedStorageClasses forbids evicting a pod that uses a PersistentVolumeClaim
+    from a listed StorageClass. The same deterministic inter-pod anti-affinity violation
+    that the single-replica test uses as an eviction trigger is applied here: with the
+    StorageClass protected the pod must stay in place, and after the protection is removed
+    from the CR the very same pod must be evicted. The second phase is the control that
+    keeps the negative assertion honest.
+  concurrent: false
+  timeouts:
+    apply: 30s
+    assert: 120s
+    delete: 60s
+
+  bindings:
+    - name: stsTestLabel
+      value: protected-sc
+    - name: conflictLabel
+      value: protected-sc-conflict
+    - name: workerNodes
+      value: >-
+        (x_k8s_list($client, 'v1', 'Node').items[?spec.unschedulable != `true`
+        && metadata.labels."node-role.kubernetes.io/control-plane" == `null`
+        && length(status.conditions[?type == 'Ready' && status == 'True']) > `0`])
+    - name: defaultStorageClasses
+      value: >-
+        (x_k8s_list($client, 'storage.k8s.io/v1', 'StorageClass').items[?metadata.annotations."storageclass.kubernetes.io/is-default-class" == 'true'])
+    - name: storageClass
+      value: ($defaultStorageClasses[0].metadata.name)
+
+  catch:
+    - description: Show pods in the test namespace on failure
+      get:
+        apiVersion: v1
+        kind: Pod
+    - description: Show PersistentVolumeClaims in the test namespace on failure
+      get:
+        apiVersion: v1
+        kind: PersistentVolumeClaim
+    - description: Show events in the test namespace on failure
+      events: {}
+    - description: Show descheduler pod logs on failure
+      podLogs:
+        namespace: d8-descheduler
+        selector: app=descheduler
+        container: descheduler
+        tail: 200
+
+  steps:
+    - name: assert-module-installed
+      description: Verify that the descheduler module is installed in the cluster
+      try:
+        - description: Assert the Descheduler CRD exists
+          assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: deschedulers.deckhouse.io
+
+    - name: check-minimum-nodes
+      description: >-
+        Verify that the cluster has at least 2 eligible worker nodes, so nodeFit would
+        allow the eviction and only the StorageClass protection stands in the way
+      try:
+        - description: Assert at least 2 Ready, schedulable, non-control-plane worker nodes exist
+          assert:
+            resource:
+              (length($workerNodes) >= `2`): true
+
+    - name: check-default-storage-class
+      description: Verify that the cluster has a default StorageClass to provision the test volume from
+      try:
+        - description: Assert exactly one default StorageClass exists
+          assert:
+            resource:
+              (length($defaultStorageClasses) == `1`): true
+
+    - name: create-statefulset
+      description: >-
+        Create a single-replica StatefulSet with a volumeClaimTemplate backed by the default
+        StorageClass. The pod is placed by the scheduler (no nodeName, no nodeSelector) so that
+        WaitForFirstConsumer volumes bind and so that nodeFit sees no node constraint on the
+        live pod. Its required podAntiAffinity against the conflict label is inert for now,
+        because no such pod exists yet
+      try:
+        - description: Create the StatefulSet with a PersistentVolumeClaim template
+          create:
+            file: manifests/sts-with-pvc.yaml
+            template: true
+
+    - name: wait-statefulset-ready
+      description: Wait until the single replica is Running and its PersistentVolumeClaim is bound
+      try:
+        - description: Assert pod test-sts-pvc-0 is Running
+          assert:
+            timeout: 300s
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: test-sts-pvc-0
+              status:
+                phase: Running
+        - description: Assert the PersistentVolumeClaim is bound to the default StorageClass
+          assert:
+            timeout: 120s
+            resource:
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+              metadata:
+                name: data-test-sts-pvc-0
+              spec:
+                storageClassName: ($storageClass)
+              status:
+                phase: Bound
+        - description: Assert the StatefulSet reports 1 ready replica
+          assert:
+            resource:
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: test-sts-pvc
+              status:
+                readyReplicas: 1
+
+    - name: create-conflict-pod
+      description: >-
+        Force-place a bare pod carrying the repelled label onto the node the StatefulSet pod
+        landed on (kubelet admission does not enforce inter-pod anti-affinity), making
+        test-sts-pvc-0 violate its own required podAntiAffinity. Kept as one step because the
+        captured node name (operation outputs) is not visible across step boundaries
+      try:
+        - description: Capture the node the StatefulSet pod runs on
+          patch:
+            resource:
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: test-sts-pvc
+                annotations:
+                  e2e.descheduler.deckhouse.io/node-capture: pre-conflict
+            outputs:
+              - name: pvcPodNode
+                value: (x_k8s_get($client, 'v1', 'Pod', $namespace, 'test-sts-pvc-0').spec.nodeName)
+        - description: Create the conflict pod on that node
+          create:
+            file: manifests/conflict-pod.yaml
+            template: true
+        - description: Assert the conflict pod is Running next to test-sts-pvc-0
+          assert:
+            timeout: 120s
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: conflict-pod
+              spec:
+                nodeName: ($pvcPodNode)
+              status:
+                phase: Running
+
+    - name: verify-protected-pod-is-not-evicted
+      description: >-
+        Apply the Descheduler CR that protects the default StorageClass and verify the pod
+        survives a full descheduling cycle despite violating its anti-affinity. Kept as one
+        step because the captured pod UID (operation outputs) is not visible across step
+        boundaries
+      try:
+        - description: Apply the Descheduler CR with protectedStorageClasses
+          apply:
+            file: manifests/descheduler-cr-protected.yaml
+            template: true
+        - description: >-
+            Assert the rendered policy carries the profile, the PodsWithPVC protection and the
+            protected StorageClass name, and no longer carries the deprecated ignorePvcPods flag
+            for this profile (mixing the two makes the descheduler reject the policy)
+          assert:
+            timeout: 120s
+            resource:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: descheduler-policy
+                namespace: d8-descheduler
+              data:
+                (contains("policy.yaml", 'e2e-protected-sc')): true
+                (contains("policy.yaml", 'podProtections')): true
+                (contains("policy.yaml", 'PodsWithPVC')): true
+                (contains("policy.yaml", $storageClass)): true
+        - description: >-
+            Assert the descheduler deployment finished rolling out and its single pod runs with
+            the current policy checksum, so the cycle below really runs against the new policy
+            (a descheduling cycle runs at pod startup)
+          assert:
+            timeout: 300s
+            file: ../common/asserts/assert-descheduler-rollout-complete.yaml
+        - description: Capture the UID of test-sts-pvc-0 before the descheduling cycle
+          patch:
+            resource:
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: test-sts-pvc
+                annotations:
+                  e2e.descheduler.deckhouse.io/uid-capture: pre-cycle
+            outputs:
+              - name: protectedPodUid
+                value: (x_k8s_get($client, 'v1', 'Pod', $namespace, 'test-sts-pvc-0').metadata.uid)
+        - description: Sleep through a full descheduling cycle running against the new policy
+          sleep:
+            duration: 300s
+        - description: Assert no anti-affinity eviction event was recorded for the protected pod
+          error:
+            timeout: 30s
+            resource:
+              apiVersion: v1
+              kind: Event
+              reason: RemovePodsViolatingInterPodAntiAffinity
+              involvedObject:
+                name: test-sts-pvc-0
+        - description: Assert the pod was never recreated (same UID) and still runs on the conflicting node
+          assert:
+            timeout: 30s
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: test-sts-pvc-0
+              (metadata.uid == $protectedPodUid): true
+              spec:
+                nodeName: ($pvcPodNode)
+              status:
+                phase: Running
+      catch:
+        - description: Show ConfigMap content on failure
+          get:
+            apiVersion: v1
+            kind: ConfigMap
+            name: descheduler-policy
+            namespace: d8-descheduler
+        - description: Show Descheduler CRs on failure
+          get:
+            apiVersion: deckhouse.io/v1alpha2
+            kind: Descheduler
+        - description: Show events in the descheduler namespace on failure
+          events:
+            namespace: d8-descheduler
+
+    - name: verify-pod-is-evicted-without-protection
+      description: >-
+        Control phase that keeps the negative assertion above honest: drop
+        protectedStorageClasses from the very same CR and verify the very same pod is now
+        evicted. Kept as one step because the captured pod UID is not visible across step
+        boundaries
+      try:
+        - description: Capture the UID of test-sts-pvc-0 before the protection is dropped
+          patch:
+            resource:
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: test-sts-pvc
+                annotations:
+                  e2e.descheduler.deckhouse.io/uid-capture: pre-control
+            outputs:
+              - name: unprotectedPodUid
+                value: (x_k8s_get($client, 'v1', 'Pod', $namespace, 'test-sts-pvc-0').metadata.uid)
+        - description: Update the Descheduler CR, removing protectedStorageClasses
+          apply:
+            file: manifests/descheduler-cr-unprotected.yaml
+        - description: Assert the rendered policy no longer carries the PodsWithPVC protection
+          assert:
+            timeout: 120s
+            resource:
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: descheduler-policy
+                namespace: d8-descheduler
+              data:
+                (contains("policy.yaml", 'e2e-protected-sc')): true
+                (contains("policy.yaml", 'PodsWithPVC')): false
+        - description: Assert the descheduler deployment finished rolling out with the updated policy
+          assert:
+            timeout: 300s
+            file: ../common/asserts/assert-descheduler-rollout-complete.yaml
+        - description: Assert test-sts-pvc-0 was evicted and recreated with a new UID
+          assert:
+            timeout: 420s
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: test-sts-pvc-0
+              (metadata.uid != $unprotectedPodUid): true
+        - description: >-
+            Assert an eviction event was recorded for test-sts-pvc-0
+            (event reason is the strategy name; 'Descheduled' is the event action)
+          assert:
+            timeout: 60s
+            resource:
+              apiVersion: v1
+              kind: Event
+              reason: RemovePodsViolatingInterPodAntiAffinity
+              involvedObject:
+                name: test-sts-pvc-0
+      cleanup:
+        - description: Delete the Descheduler CR
+          delete:
+            ref:
+              apiVersion: deckhouse.io/v1alpha2
+              kind: Descheduler
+              name: e2e-protected-sc
+      catch:
+        - description: Show ConfigMap content on failure
+          get:
+            apiVersion: v1
+            kind: ConfigMap
+            name: descheduler-policy
+            namespace: d8-descheduler
+        - description: Show Descheduler CRs on failure
+          get:
+            apiVersion: deckhouse.io/v1alpha2
+            kind: Descheduler
+        - description: Show events in the descheduler namespace on failure
+          events:
+            namespace: d8-descheduler

--- a/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/manifests/conflict-pod.yaml
+++ b/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/manifests/conflict-pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: conflict-pod
+  labels:
+    e2e-test: ($conflictLabel)
+spec:
+  nodeName: ($pvcPodNode)
+  terminationGracePeriodSeconds: 5
+  containers:
+    - name: pause
+      image: registry.k8s.io/pause:3.9
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi

--- a/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/manifests/descheduler-cr-protected.yaml
+++ b/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/manifests/descheduler-cr-protected.yaml
@@ -1,0 +1,13 @@
+apiVersion: deckhouse.io/v1alpha2
+kind: Descheduler
+metadata:
+  name: e2e-protected-sc
+spec:
+  podLabelSelector:
+    matchLabels:
+      e2e-test: protected-sc
+  protectedStorageClasses:
+    - ($storageClass)
+  strategies:
+    removePodsViolatingInterPodAntiAffinity:
+      enabled: true

--- a/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/manifests/descheduler-cr-unprotected.yaml
+++ b/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/manifests/descheduler-cr-unprotected.yaml
@@ -1,0 +1,11 @@
+apiVersion: deckhouse.io/v1alpha2
+kind: Descheduler
+metadata:
+  name: e2e-protected-sc
+spec:
+  podLabelSelector:
+    matchLabels:
+      e2e-test: protected-sc
+  strategies:
+    removePodsViolatingInterPodAntiAffinity:
+      enabled: true

--- a/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/manifests/sts-with-pvc.yaml
+++ b/modules/400-descheduler/e2e/descheduler/tests/protected-storage-class-blocks-eviction/manifests/sts-with-pvc.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-sts-pvc
+  labels:
+    e2e-test: ($stsTestLabel)
+spec:
+  serviceName: test-sts-pvc
+  replicas: 1
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      e2e-test: ($stsTestLabel)
+  template:
+    metadata:
+      labels:
+        e2e-test: ($stsTestLabel)
+    spec:
+      terminationGracePeriodSeconds: 5
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  e2e-test: ($conflictLabel)
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: ($storageClass)
+        resources:
+          requests:
+            storage: 1Gi

--- a/modules/400-descheduler/hooks/get_crds.go
+++ b/modules/400-descheduler/hooks/get_crds.go
@@ -74,7 +74,9 @@ type InternalValuesDeschedulerSpec struct {
 	NamespaceLabelSelector *metav1.LabelSelector              `json:"namespaceLabelSelector,omitempty" yaml:"namespaceLabelSelector,omitempty"`
 	PriorityClassThreshold *dsv1alpha2.PriorityClassThreshold `json:"priorityClassThreshold,omitempty" yaml:"priorityClassThreshold,omitempty"`
 	EvictLocalStoragePods  *dsv1alpha2.EvictLocalStoragePods  `json:"evictLocalStoragePods,omitempty" yaml:"evictLocalStoragePods,omitempty"`
-	Strategies             dsv1alpha2.Strategies              `json:"strategies" yaml:"strategies"`
+	// ProtectedStorageClasses lists StorageClass names whose Pods must not be evicted.
+	ProtectedStorageClasses []string              `json:"protectedStorageClasses,omitempty" yaml:"protectedStorageClasses,omitempty"`
+	Strategies              dsv1alpha2.Strategies `json:"strategies" yaml:"strategies"`
 }
 
 func getCRDsHandler(_ context.Context, input *go_hook.HookInput) error {
@@ -105,6 +107,9 @@ func getCRDsHandler(_ context.Context, input *go_hook.HookInput) error {
 		}
 		if item.Spec.EvictLocalStoragePods != nil {
 			ds.EvictLocalStoragePods = item.Spec.EvictLocalStoragePods
+		}
+		if len(item.Spec.ProtectedStorageClasses) > 0 {
+			ds.ProtectedStorageClasses = item.Spec.ProtectedStorageClasses
 		}
 
 		if !item.Spec.Strategies.HasValidStrategies() {

--- a/modules/400-descheduler/hooks/get_crds_test.go
+++ b/modules/400-descheduler/hooks/get_crds_test.go
@@ -160,6 +160,22 @@ spec:
       podRestartThreshold: 50
 `
 
+	deschedulerCR8 = `
+---
+apiVersion: deckhouse.io/v1alpha2
+kind: Descheduler
+metadata:
+  name: test8
+spec:
+  evictLocalStoragePods: true
+  protectedStorageClasses:
+  - local-path
+  - ceph-rbd
+  strategies:
+    removeDuplicates:
+      enabled: true
+`
+
 	// Simulates a Descheduler CR that was converted from v1alpha1
 	// with only deprecated strategies (e.g. removePodsViolatingNodeTaints).
 	// After conversion, all deprecated strategies are stripped and spec.strategies is empty.
@@ -406,6 +422,28 @@ var _ = Describe("Modules :: descheduler :: hooks :: get_crds ::", func() {
       constraints:
         - DoNotSchedule
       topologyBalanceNodeFit: true
+`))
+		})
+	})
+
+	Context("Cluster with Descheduler CR with protectedStorageClasses", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(deschedulerCR8)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should pass protectedStorageClasses to internal values", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("descheduler.internal.deschedulers").String()).To(MatchYAML(`
+- name: test8
+  evictLocalStoragePods: true
+  protectedStorageClasses:
+  - local-path
+  - ceph-rbd
+  strategies:
+    removeDuplicates:
+      enabled: true
 `))
 		})
 	})

--- a/modules/400-descheduler/hooks/internal/v1alpha2/descheduler.go
+++ b/modules/400-descheduler/hooks/internal/v1alpha2/descheduler.go
@@ -42,7 +42,9 @@ type DeschedulerSpec struct {
 	NamespaceLabelSelector *metav1.LabelSelector   `json:"namespaceLabelSelector,omitempty" yaml:"namespaceLabelSelector,omitempty"`
 	PriorityClassThreshold *PriorityClassThreshold `json:"priorityClassThreshold,omitempty" yaml:"priorityClassThreshold,omitempty"`
 	EvictLocalStoragePods  *EvictLocalStoragePods  `json:"evictLocalStoragePods,omitempty" yaml:"evictLocalStoragePods,omitempty"`
-	Strategies             Strategies              `json:"strategies" yaml:"strategies"`
+	// ProtectedStorageClasses lists StorageClass names whose Pods must not be evicted.
+	ProtectedStorageClasses []string   `json:"protectedStorageClasses,omitempty" yaml:"protectedStorageClasses,omitempty"`
+	Strategies              Strategies `json:"strategies" yaml:"strategies"`
 }
 
 type PriorityClassThreshold struct {

--- a/modules/400-descheduler/openapi/openapi-case-tests.yaml
+++ b/modules/400-descheduler/openapi/openapi-case-tests.yaml
@@ -49,6 +49,14 @@ positive:
                   memory: 50
                   pods: 50
                   gpu: "gpuNode"
+          - name: test4
+            evictLocalStoragePods: true
+            protectedStorageClasses:
+              - local-path
+              - ceph-rbd
+            strategies:
+              removeDuplicates:
+                enabled: true
           - name: test3
             evictLocalStoragePods: false
             strategies:
@@ -65,6 +73,22 @@ positive:
                   gpu: "gpuNode"
 negative:
   values:
+    - internal:
+        deschedulers:
+          - name: test1
+            protectedStorageClasses: []
+            strategies:
+              removeDuplicates:
+                enabled: true
+    - internal:
+        deschedulers:
+          - name: test1
+            protectedStorageClasses:
+              - local-path
+              - local-path
+            strategies:
+              removeDuplicates:
+                enabled: true
     - deschedulingInterval: "invalid"
       internal:
         deschedulers: []

--- a/modules/400-descheduler/openapi/values.yaml
+++ b/modules/400-descheduler/openapi/values.yaml
@@ -149,6 +149,16 @@ properties:
                 - required: ["value"]
             evictLocalStoragePods:
               type: boolean
+            protectedStorageClasses:
+              type: array
+              description: A list of StorageClass names whose Pods must not be evicted.
+              items:
+                type: string
+                description: A StorageClass name.
+                minLength: 1
+                maxLength: 253
+              minItems: 1
+              uniqueItems: true
             strategies:
               type: object
               default: {}

--- a/modules/400-descheduler/template_tests/module_test.go
+++ b/modules/400-descheduler/template_tests/module_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package template_tests
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -428,6 +429,133 @@ profiles:
       enabled:
       - DefaultEvictor
 `))
+		})
+	})
+
+	Context("With protectedStorageClasses set", func() {
+		BeforeEach(func() {
+			moduleValues := `
+internal:
+  deschedulers:
+  - name: test1
+    evictLocalStoragePods: true
+    protectedStorageClasses:
+    - local-path
+    - ceph-rbd
+    strategies:
+      removeDuplicates:
+        enabled: true
+  - name: test2
+    protectedStorageClasses:
+    - local-path
+    strategies:
+      removeDuplicates:
+        enabled: true
+  - name: test3
+    strategies:
+      removeDuplicates:
+        enabled: true
+`
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("descheduler", moduleValues)
+			f.HelmRender()
+		})
+
+		It("Should render podProtections instead of the deprecated flags", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			cm := f.KubernetesResource("ConfigMap", "d8-descheduler", "descheduler-policy")
+			Expect(cm.Field(`data.policy\.yaml`)).To(MatchYAML(`---
+apiVersion: descheduler/v1alpha2
+kind: DeschedulerPolicy
+profiles:
+- name: test1
+  pluginConfig:
+  - args:
+      nodeFit: true
+      podProtections:
+        defaultDisabled:
+        - FailedBarePods
+        - PodsWithLocalStorage
+        extraEnabled:
+        - PodsWithPVC
+        config:
+          PodsWithPVC:
+            protectedStorageClasses:
+            - name: local-path
+            - name: ceph-rbd
+    name: DefaultEvictor
+  - name: RemoveDuplicates
+  plugins:
+    balance:
+      enabled:
+      - RemoveDuplicates
+    filter:
+      enabled:
+      - DefaultEvictor
+    preEvictionFilter:
+      enabled:
+      - DefaultEvictor
+- name: test2
+  pluginConfig:
+  - args:
+      nodeFit: true
+      podProtections:
+        defaultDisabled:
+        - FailedBarePods
+        extraEnabled:
+        - PodsWithPVC
+        config:
+          PodsWithPVC:
+            protectedStorageClasses:
+            - name: local-path
+    name: DefaultEvictor
+  - name: RemoveDuplicates
+  plugins:
+    balance:
+      enabled:
+      - RemoveDuplicates
+    filter:
+      enabled:
+      - DefaultEvictor
+    preEvictionFilter:
+      enabled:
+      - DefaultEvictor
+- name: test3
+  pluginConfig:
+  - args:
+      evictFailedBarePods: true
+      evictLocalStoragePods: false
+      evictSystemCriticalPods: false
+      ignorePvcPods: false
+      nodeFit: true
+    name: DefaultEvictor
+  - name: RemoveDuplicates
+  plugins:
+    balance:
+      enabled:
+      - RemoveDuplicates
+    filter:
+      enabled:
+      - DefaultEvictor
+    preEvictionFilter:
+      enabled:
+      - DefaultEvictor
+`))
+		})
+
+		It("Should not mix the deprecated evictor flags with podProtections", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			cm := f.KubernetesResource("ConfigMap", "d8-descheduler", "descheduler-policy")
+			policy := cm.Field(`data.policy\.yaml`).String()
+			// Upstream DefaultEvictor validation rejects a policy that sets both,
+			// and the descheduler refuses to start in that case.
+			Expect(strings.Count(policy, "podProtections:")).To(Equal(2))
+			// Only the legacy profile (test3) keeps the deprecated flags.
+			Expect(strings.Count(policy, "evictFailedBarePods:")).To(Equal(1))
+			Expect(strings.Count(policy, "evictLocalStoragePods:")).To(Equal(1))
+			Expect(strings.Count(policy, "evictSystemCriticalPods:")).To(Equal(1))
+			Expect(strings.Count(policy, "ignorePvcPods:")).To(Equal(1))
 		})
 	})
 })

--- a/modules/400-descheduler/templates/configmap.yaml
+++ b/modules/400-descheduler/templates/configmap.yaml
@@ -23,10 +23,40 @@ data:
           {{- if $d.nodeLabelSelector }}
           nodeSelector: {{ $d.nodeLabelSelector }}
           {{- end }}
+          {{- if $d.protectedStorageClasses }}
+          {{- /*
+            Upstream forbids mixing the deprecated boolean flags (evictLocalStoragePods,
+            evictSystemCriticalPods, ignorePvcPods, evictFailedBarePods) with podProtections:
+            DefaultEvictor validation rejects such a policy and the descheduler refuses to start.
+            So when protectedStorageClasses is set, the very same behaviour is expressed
+            through podProtections only.
+            Default protections are: PodsWithLocalStorage, SystemCriticalPods, FailedBarePods, DaemonSetPods.
+            Disabling FailedBarePods is the equivalent of `evictFailedBarePods: true`,
+            disabling PodsWithLocalStorage is the equivalent of `evictLocalStoragePods: true`.
+            The `PodsWithPVC` key under `config` is upper-camel-cased on purpose:
+            it must match the protection name, and an unknown key is silently ignored,
+            which would protect every Pod with a PVC instead of the listed StorageClasses only.
+          */}}
+          podProtections:
+            defaultDisabled:
+            - "FailedBarePods"
+            {{- if $d.evictLocalStoragePods }}
+            - "PodsWithLocalStorage"
+            {{- end }}
+            extraEnabled:
+            - "PodsWithPVC"
+            config:
+              PodsWithPVC:
+                protectedStorageClasses:
+                {{- range $d.protectedStorageClasses }}
+                - name: {{ . | quote }}
+                {{- end }}
+          {{- else }}
           evictLocalStoragePods: {{ if $d.evictLocalStoragePods }}{{ $d.evictLocalStoragePods }}{{- else }}false{{- end }}
           evictSystemCriticalPods: false
           ignorePvcPods: false
           evictFailedBarePods: true
+          {{- end }}
           nodeFit: true
           {{- if $d.podLabelSelector }}
           labelSelector:


### PR DESCRIPTION
## Description

Adds a new optional parameter `spec.protectedStorageClasses` to the `Descheduler` CR (`deckhouse.io/v1alpha2`): a list of StorageClass names whose Pods must never be evicted.

When the list is non-empty, the rendered `descheduler-policy` ConfigMap expresses the `DefaultEvictor` configuration through the upstream `podProtections` API instead of the deprecated boolean flags:

```yaml
podProtections:
  defaultDisabled:
  - "FailedBarePods"          # equivalent of the current `evictFailedBarePods: true`
  - "PodsWithLocalStorage"    # only when `evictLocalStoragePods: true`
  extraEnabled:
  - "PodsWithPVC"
  config:
    PodsWithPVC:
      protectedStorageClasses:
      - name: "local-path"
```

This is deliberately an either/or branch in the template, not an addition to the existing args. Upstream `ValidateDefaultEvictorArgs` (descheduler v0.36.0) rejects a policy that sets any deprecated flag together with `podProtections.extraEnabled`/`defaultDisabled`, and the module always renders `evictFailedBarePods: true` — appending the block would have made the descheduler fail to load its policy and CrashLoop for every CR using the new parameter. The branch reproduces the current behavior exactly via the equivalent protection names.

When the parameter is omitted or empty, the rendered policy is byte-for-byte unchanged, so existing `Descheduler` CRs are not affected.

Two behaviors worth knowing about, both documented in the CR schema and in EXAMPLES:

- An empty list is not "protect everything": the block is not rendered at all, and Pods with PVCs keep being evicted as before. Upstream treats an empty `protectedStorageClasses` under an enabled `PodsWithPVC` as "protect every Pod with a PVC", which is why the CRD enforces `minItems: 1`.
- A Pod whose PVC cannot be resolved (the PVC is missing, or its `storageClassName` is empty) is treated as protected too — upstream fails closed here.

No changes to RBAC were needed: `get/watch/list` on `persistentvolumeclaims` is already granted, and descheduler v0.36.0 registers the PVC informer unconditionally, so the permission is already required today. `storageclasses` permissions are not needed — the StorageClass is resolved from `pvc.spec.storageClassName`.

No changes to the conversion webhook were needed either: `v1alpha2` is the storage version, and the `v1alpha2 → v1alpha1` handler rebuilds the v1alpha1 spec, so the new field is dropped by structural schema pruning exactly like `evictLocalStoragePods` already is.

**Impact on critical cluster components:** none. Only the `descheduler` Deployment in `d8-descheduler` is affected, and only for clusters that actually set the new parameter: changing a `Descheduler` CR updates the policy ConfigMap checksum and rolls the single descheduler Pod, which is the existing behavior for any CR change.

## Why do we need it, and what problem does it solve?

Today the only PVC-related knob exposed by the module is all-or-nothing: upstream `ignorePvcPods` (hardcoded to `false` in the template) either protects every Pod with a PersistentVolumeClaim or none of them. There is no way to say "do not move Pods that sit on node-local storage, but keep rebalancing everything else".

This matters for storage that is bound to a node — `local-path`, LVM/local-volume based classes, and similar. Evicting such a Pod either destroys data locality or leaves the Pod unschedulable, because its volume only exists on the node it was evicted from. Users currently have to choose between disabling the descheduler for those workloads entirely (per-CR `podLabelSelector` gymnastics that has to be kept in sync by hand) and letting it break them.

`protectedStorageClasses` makes the protection declarative and storage-driven: name the StorageClasses that must not be disturbed, and the descheduler keeps rebalancing everything else.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: descheduler
type: feature
summary: Added the `protectedStorageClasses` parameter to the Descheduler custom resource, which forbids evicting Pods that use a PersistentVolumeClaim from the listed StorageClasses.
impact_level: default
```