### PR TITLE
[user-authz] Fire the slow-render and slow-release alerts on repetition, not on a single observation

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3539,26 +3539,19 @@ alerts:
       module: user-authz
       edition: ce
       description: |-
-        Applying the `user-authz` Helm release took more than 5 minutes on average over the last 30 minutes. A release that does not finish within the module release timeout (20 minutes) fails, changes to ClusterAuthorizationRule and AuthorizationRule objects stop being applied and platform updates stall (the `D8DeckhouseCouldNotRunModule` alert fires in that case).
+        Applying the `user-authz` Helm release took more than 5 minutes on average over the last hour, and it was applied at least twice in that hour, so this is not the single slow pass of a cluster bootstrap or of the one-time migration to `user-authz-controller`. A release that does not finish within the module release timeout (20 minutes) fails, changes to ClusterAuthorizationRule and AuthorizationRule objects stop being applied and platform updates stall (the `D8DeckhouseCouldNotRunModule` alert fires in that case).
 
-        The usual cause is the size of the release: thousands of ClusterAuthorizationRule/AuthorizationRule objects, or many ClusterRoles annotated with `user-authz.deckhouse.io/access-level` bound one by one. Check the number of rules and of the module bindings:
-
-        ```bash
-        d8 k get clusterauthorizationrules --no-headers | wc -l
-        d8 k get authorizationrules -A --no-headers | wc -l
-        d8 k get clusterrolebindings -l heritage=deckhouse,module=user-authz --no-headers | wc -l
-        d8 k get rolebindings -A -l heritage=deckhouse,module=user-authz --no-headers | wc -l
-        ```
-
-        Check the module queue and the Deckhouse log for the release:
+        The release itself no longer grows with the number of rules: bindings are managed by `user-authz-controller`, and custom ClusterRoles are aggregated. A slow release therefore points outside the module: an API server that answers slowly, an object stuck with a finalizer, a Deckhouse Pod short of CPU, or the release engine itself. Check what the release is waiting on:
 
         ```bash
         d8 s queue list
         d8 k -n d8-system logs deploy/deckhouse | grep '"module":"user-authz"'
         ```
+
+        If the cluster has just been updated to the release that moved the bindings to the controller, one slow pass is expected and does not raise this alert by itself; if it fires anyway, the pass is being retried. It is proportional to the number of bindings and can exceed the timeout on clusters with more than 5000 of them; the module FAQ describes what to do in that case.
       summary: |
-        The user-authz module release takes more than 5 minutes.
-      severity: "5"
+        The user-authz module release repeatedly takes more than 5 minutes.
+      severity: "6"
       markupFormat: markdown
     - name: D8UserAuthzRenderSlow
       sourceFile: modules/140-user-authz/monitoring/prometheus-rules/release-duration.yaml
@@ -3566,18 +3559,21 @@ alerts:
       module: user-authz
       edition: ce
       description: |-
-        Rendering the templates of the `user-authz` module took more than 30 seconds on average over the last 30 minutes; normally it takes about a second. Render time grows with the number of objects in the release, so this is an early sign that the release is getting too large and may stop fitting into the module release timeout.
+        Rendering the templates of the `user-authz` module took more than 30 seconds on average over the last 30 minutes, across at least three renders; normally one render takes about a second. Rendering is CPU work inside the Deckhouse Pod and does not depend on the number of ClusterAuthorizationRule or AuthorizationRule objects, so the cause is the node, not the module: most often the Deckhouse Pod is short of CPU (CPU steal on a virtual machine, a node running at its limits, a bootstrap that starts every module at once).
 
-        Check the number of rules and of the module bindings:
+        A single slow render during a cluster bootstrap does not raise this alert by itself. If it fires, compare the module with the others and look at the node:
+
+        ```promql
+        topk(10, increase(deckhouse_helm_operation_seconds_sum{operation="template"}[30m]) / increase(deckhouse_helm_operation_seconds_count{operation="template"}[30m]))
+        rate(node_cpu_seconds_total{mode="steal"}[5m])
+        ```
 
         ```bash
-        d8 k get clusterauthorizationrules --no-headers | wc -l
-        d8 k get authorizationrules -A --no-headers | wc -l
-        d8 k get clusterrolebindings -l heritage=deckhouse,module=user-authz --no-headers | wc -l
+        d8 k -n d8-system logs deploy/deckhouse | grep '"module":"user-authz"'
         ```
       summary: |
-        Rendering the user-authz module templates takes more than 30 seconds.
-      severity: "6"
+        Rendering the user-authz module templates repeatedly takes more than 30 seconds.
+      severity: "7"
       markupFormat: markdown
     - name: D8UsingFeatureGateWillBeDeprecated
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml

--- a/modules/140-user-authz/monitoring/prometheus-rules/release-duration.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/release-duration.yaml
@@ -1,51 +1,21 @@
 - name: d8.user-authz.release-duration
   rules:
+  # Both alerts are averages of a histogram over a window, and an average over a window that holds
+  # one observation is that observation. A freshly bootstrapped cluster renders and applies every
+  # module once, under whatever CPU the node has left at that moment, and the one-time migration
+  # pass of a platform update applies the release once, slowly on purpose. Each of those used to
+  # keep an alert firing for the whole window on its own. Both now demand repetition: a slow
+  # release is a problem when it happens again, not when it happens once.
   - alert: D8UserAuthzReleaseSlow
     expr: |
       (
-        sum(increase(deckhouse_helm_operation_seconds_sum{module="user-authz", operation="upgrade"}[30m]))
+        sum(increase(deckhouse_helm_operation_seconds_sum{module="user-authz", operation="upgrade"}[1h]))
         /
-        sum(increase(deckhouse_helm_operation_seconds_count{module="user-authz", operation="upgrade"}[30m]))
+        sum(increase(deckhouse_helm_operation_seconds_count{module="user-authz", operation="upgrade"}[1h]))
       ) > 300
-    for: 1m
-    labels:
-      severity_level: "5"
-      tier: cluster
-      d8_module: user-authz
-      d8_component: user-authz
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      summary: The user-authz module release takes more than 5 minutes.
-      description: |-
-        Applying the `user-authz` Helm release took more than 5 minutes on average over the last 30 minutes. A release that does not finish within the module release timeout (20 minutes) fails, changes to ClusterAuthorizationRule and AuthorizationRule objects stop being applied and platform updates stall (the `D8DeckhouseCouldNotRunModule` alert fires in that case).
-
-        The usual cause is the size of the release: thousands of ClusterAuthorizationRule/AuthorizationRule objects, or many ClusterRoles annotated with `user-authz.deckhouse.io/access-level` bound one by one. Check the number of rules and of the module bindings:
-
-        ```bash
-        d8 k get clusterauthorizationrules --no-headers | wc -l
-        d8 k get authorizationrules -A --no-headers | wc -l
-        d8 k get clusterrolebindings -l heritage=deckhouse,module=user-authz --no-headers | wc -l
-        d8 k get rolebindings -A -l heritage=deckhouse,module=user-authz --no-headers | wc -l
-        ```
-
-        Check the module queue and the Deckhouse log for the release:
-
-        ```bash
-        d8 s queue list
-        d8 k -n d8-system logs deploy/deckhouse | grep '"module":"user-authz"'
-        ```
-
-  - alert: D8UserAuthzRenderSlow
-    expr: |
-      (
-        sum(increase(deckhouse_helm_operation_seconds_sum{module="user-authz", operation="template"}[30m]))
-        /
-        sum(increase(deckhouse_helm_operation_seconds_count{module="user-authz", operation="template"}[30m]))
-      ) > 30
-    for: 1m
+      and
+      sum(increase(deckhouse_helm_operation_seconds_count{module="user-authz", operation="upgrade"}[1h])) >= 2
+    for: 15m
     labels:
       severity_level: "6"
       tier: cluster
@@ -56,14 +26,50 @@
       plk_markup_format: "markdown"
       plk_create_group_if_not_exists__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      summary: Rendering the user-authz module templates takes more than 30 seconds.
+      summary: The user-authz module release repeatedly takes more than 5 minutes.
       description: |-
-        Rendering the templates of the `user-authz` module took more than 30 seconds on average over the last 30 minutes; normally it takes about a second. Render time grows with the number of objects in the release, so this is an early sign that the release is getting too large and may stop fitting into the module release timeout.
+        Applying the `user-authz` Helm release took more than 5 minutes on average over the last hour, and it was applied at least twice in that hour, so this is not the single slow pass of a cluster bootstrap or of the one-time migration to `user-authz-controller`. A release that does not finish within the module release timeout (20 minutes) fails, changes to ClusterAuthorizationRule and AuthorizationRule objects stop being applied and platform updates stall (the `D8DeckhouseCouldNotRunModule` alert fires in that case).
 
-        Check the number of rules and of the module bindings:
+        The release itself no longer grows with the number of rules: bindings are managed by `user-authz-controller`, and custom ClusterRoles are aggregated. A slow release therefore points outside the module: an API server that answers slowly, an object stuck with a finalizer, a Deckhouse Pod short of CPU, or the release engine itself. Check what the release is waiting on:
 
         ```bash
-        d8 k get clusterauthorizationrules --no-headers | wc -l
-        d8 k get authorizationrules -A --no-headers | wc -l
-        d8 k get clusterrolebindings -l heritage=deckhouse,module=user-authz --no-headers | wc -l
+        d8 s queue list
+        d8 k -n d8-system logs deploy/deckhouse | grep '"module":"user-authz"'
+        ```
+
+        If the cluster has just been updated to the release that moved the bindings to the controller, one slow pass is expected and does not raise this alert by itself; if it fires anyway, the pass is being retried. It is proportional to the number of bindings and can exceed the timeout on clusters with more than 5000 of them; the module FAQ describes what to do in that case.
+
+  - alert: D8UserAuthzRenderSlow
+    expr: |
+      (
+        sum(increase(deckhouse_helm_operation_seconds_sum{module="user-authz", operation="template"}[30m]))
+        /
+        sum(increase(deckhouse_helm_operation_seconds_count{module="user-authz", operation="template"}[30m]))
+      ) > 30
+      and
+      sum(increase(deckhouse_helm_operation_seconds_count{module="user-authz", operation="template"}[30m])) >= 3
+    for: 15m
+    labels:
+      severity_level: "7"
+      tier: cluster
+      d8_module: user-authz
+      d8_component: user-authz
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      summary: Rendering the user-authz module templates repeatedly takes more than 30 seconds.
+      description: |-
+        Rendering the templates of the `user-authz` module took more than 30 seconds on average over the last 30 minutes, across at least three renders; normally one render takes about a second. Rendering is CPU work inside the Deckhouse Pod and does not depend on the number of ClusterAuthorizationRule or AuthorizationRule objects, so the cause is the node, not the module: most often the Deckhouse Pod is short of CPU (CPU steal on a virtual machine, a node running at its limits, a bootstrap that starts every module at once).
+
+        A single slow render during a cluster bootstrap does not raise this alert by itself. If it fires, compare the module with the others and look at the node:
+
+        ```promql
+        topk(10, increase(deckhouse_helm_operation_seconds_sum{operation="template"}[30m]) / increase(deckhouse_helm_operation_seconds_count{operation="template"}[30m]))
+        rate(node_cpu_seconds_total{mode="steal"}[5m])
+        ```
+
+        ```bash
+        d8 k -n d8-system logs deploy/deckhouse | grep '"module":"user-authz"'
         ```


### PR DESCRIPTION
## Description

`D8UserAuthzRenderSlow` and `D8UserAuthzReleaseSlow` fired on a freshly bootstrapped cluster with
zero ClusterAuthorizationRules, while `CPUStealHigh` was firing on every node. Both alerts are an
average of `deckhouse_helm_operation_seconds` over a window, and an average over a window that holds
one observation is that observation: the single render of the bootstrap, done while every module
starts at once on a node with stolen CPU, kept the alert firing for the whole 30-minute window even
though every later render took about a second. `for: 1m` added nothing.

Both alerts now require repetition before they fire:

- `D8UserAuthzRenderSlow`: the average over 30 minutes still has to exceed 30 seconds, but there
  must be **at least three renders** in the window, and the condition must hold for 15 minutes. One
  slow bootstrap render cannot raise it.
- `D8UserAuthzReleaseSlow`: the window grows to one hour, there must be **at least two releases** in
  it, and the condition must hold for 15 minutes. The one-time migration pass to
  `user-authz-controller` and a slow bootstrap release cannot raise it on their own; a release that
  is slow again does.

Both are also one step less severe: `D8UserAuthzReleaseSlow` moves from severity 5 to 6 and
`D8UserAuthzRenderSlow` from 6 to 7. Neither means the module is down — a slow release fails loudly
through `D8DeckhouseCouldNotRunModule`, and a slow render is a symptom of the node — so neither
deserves to page as if it were.

The descriptions are rewritten to say where the cause actually is. Rendering is CPU work inside the
Deckhouse Pod and does not depend on the number of rules, so the old advice to count
ClusterAuthorizationRules pointed the reader at the wrong thing; the new text names CPU shortage
and bootstrap first and gives the PromQL to compare the module with the others and to look at CPU
steal. The release description no longer blames the size of the release, which stopped growing with
the number of rules once the bindings moved to the controller.

The generated alert reference (`docs/documentation/_data/deckhouse-alerts.yml`) is updated to
match; no other documentation changes.

## Why do we need it, and what problem does it solve?

An alert with a wrong root-cause hint, firing for half an hour on every fresh
cluster whose node is under CPU pressure, costs an engineer a debugging session that ends in
"nothing is wrong". The alerts exist to catch a release that genuinely stops fitting into its
timeout; that is a repeated condition, and the rules now say so.

## Why do we need it in the patch release (if we do)?

The alerts shipped with the custom-role aggregation change, which is in `release-1.76` and
`release-1.77`; every cluster on those releases gets the same false alarm on bootstrap and on
every CPU-starved render. The change is two alert rules and their generated reference, with no
effect on the module's behaviour.

## Checklist
- [x] The code is covered by unit tests — the expressions are parsed with the Prometheus PromQL parser; there is no behaviour to unit-test beyond that.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes — the generated alert reference is in sync; nothing else describes these alerts.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: The D8UserAuthzRenderSlow and D8UserAuthzReleaseSlow alerts no longer fire on a single slow render or release, such as a cluster bootstrap under CPU pressure or the one-time migration pass.
impact: |
  D8UserAuthzRenderSlow requires at least three renders averaging above 30 seconds over 30 minutes,
  D8UserAuthzReleaseSlow at least two releases averaging above 5 minutes over one hour, and both must
  hold for 15 minutes. Severities are one step lower (6 and 7). Their descriptions now point at CPU
  shortage on the node rather than at the number of ClusterAuthorizationRules, which does not affect
  render time.
impact_level: low
```
