### PR TITLE
Backport: [user-authz] Name the alert groups apart from their member alerts

### DIFF
--- a/modules/140-user-authz/monitoring/prometheus-rules/release-duration.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/release-duration.yaml
@@ -16,8 +16,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_user_authz_release_slow: "D8UserAuthzReleaseSlow,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_user_authz_release_slow: "D8UserAuthzReleaseSlow,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: The user-authz module release takes more than 5 minutes.
       description: |-
         Applying the `user-authz` Helm release took more than 5 minutes on average over the last 30 minutes. A release that does not finish within the module release timeout (20 minutes) fails, changes to ClusterAuthorizationRule and AuthorizationRule objects stop being applied and platform updates stall (the `D8DeckhouseCouldNotRunModule` alert fires in that case).
@@ -54,8 +54,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_user_authz_render_slow: "D8UserAuthzRenderSlow,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_user_authz_render_slow: "D8UserAuthzRenderSlow,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authz_malfunctioning: "D8UserAuthzMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: Rendering the user-authz module templates takes more than 30 seconds.
       description: |-
         Rendering the templates of the `user-authz` module took more than 30 seconds on average over the last 30 minutes; normally it takes about a second. Render time grows with the number of objects in the release, so this is an early sign that the release is getting too large and may stop fitting into the module release timeout.


### PR DESCRIPTION
## Description

Manual backport of #22928 to `release-1.76`. The automatic cherry-pick failed with two
modify/delete conflicts: the original commit touches three alert-rule files, and two of them —
`legacy-rbacv2-custom-roles.yaml` and `permission-browser-apiserver.yaml` — do not exist in this
branch (those alerts arrived after 1.76 branched). This PR carries the third file only,
`release-duration.yaml`, identical to its content on `main` after #22928.

`D8UserAuthzReleaseSlow` and `D8UserAuthzRenderSlow` grouped themselves under a group carrying the
alert's own name, which the incident shelf refuses:

```
Couldn't create event due to error: Usage of current alert's trigger (D8UserAuthzRenderSlow) is forbidden in grouping to prevent circular dependencies!
```

Both now group under `D8UserAuthzMalfunctioning`, the way `D8DeckhouseMalfunctioning` groups the
`deckhouse` module alerts. Only the grouping annotations change; expressions, labels, severities and
descriptions stay as they are, and `docs/documentation/_data/deckhouse-alerts.yml` regenerates
without a diff.

## Why do we need it, and what problem does it solve?

With the self-referencing group the shelf cannot create the event for the alert, so a firing
`D8UserAuthzRenderSlow` or `D8UserAuthzReleaseSlow` is not delivered. Both alerts are in
`release-1.76` through the backport of #22824 (#22968).

## Why do we need it in the patch release (if we do)?

The two alerts are already in `release-1.76`, and without this change they cannot be delivered.
It also brings the file to the same content as on `main`, so the follow-up fix of the alerts
themselves (#22993) applies to this branch cleanly instead of producing a mangled three-block rule
file, which is what a blind cherry-pick of #22993 onto the current `release-1.76` does.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes — the generated alert reference does not carry grouping annotations, so nothing changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Group the module alerts under a group named apart from the alerts themselves, so the incident shelf accepts them.
```
