### PR TITLE
[admission-policy-engine] Fix a SecurityPolicy that only forbids hostNetwork

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allow-host-network.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allow-host-network.yaml
@@ -89,8 +89,7 @@ spec:
                 spe_ports_path := ["spec", "network", "hostPorts"]
                 spe_ports_applied := path_value_resolved(spe, spe_ports_path)
                 spe_ports := allowed_values_or_empty(spe, spe_ports_path)
-                effective_ranges := port_ranges(spe_ports_applied)
-                range_result := check_ports_with_protocol_in_ranges(ports, "hostPorts", effective_ranges, spe_ports)
+                range_result := host_port_result(ports, spe_ports_applied, spe_ports)
                 failed := failed_result(bool_result, range_result)
                 msg := violation_message("The hostNetwork or hostPort are not allowed", sprintf("%v: %v", [review_kind, obj.metadata.name]), failed.detail)
               }
@@ -184,7 +183,27 @@ spec:
                 ports := host_ports
               }
 
-              port_ranges(true) := []
+              # `allowedHostPorts` is optional, and omitting it places no restriction on host ports,
+              # while an empty list forbids every one of them. The check has to stay total either
+              # way: the constraint is also rendered for a policy that only sets `allowHostNetwork`,
+              # and reading an absent `parameters.ranges` left the whole violation rule undefined,
+              # so such a policy silently stopped denying anything at all.
+              host_port_result(_, false, _) := {"allowed": true, "msg": "", "detail": {}} if {
+                not host_port_ranges_configured
+              }
 
-              port_ranges(false) := input.parameters.ranges
+              host_port_result(ports, false, spe_ports) := result if {
+                host_port_ranges_configured
+                result := check_ports_with_protocol_in_ranges(ports, "hostPorts", input.parameters.ranges, spe_ports)
+              }
+
+              # An exception that names host ports governs them on its own, so the policy ranges
+              # give way to it.
+              host_port_result(ports, true, spe_ports) := result if {
+                result := check_ports_with_protocol_in_ranges(ports, "hostPorts", [], spe_ports)
+              }
+
+              host_port_ranges_configured if {
+                object.get(input.parameters, "ranges", null) != null
+              }
  

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-host-network/constraints/policy_2.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-host-network/constraints/policy_2.yaml
@@ -1,0 +1,21 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: D8HostNetwork
+metadata:
+  name: security-policy-2
+spec:
+  enforcementAction: "deny"
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet"]
+      - apiGroups: [""]
+        kinds: ["ReplicationController"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    namespaceSelector:
+      matchLabels:
+        custom-policy: example
+  parameters:
+    allowHostNetwork: false

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-host-network/test-matrix.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-host-network/test-matrix.yaml
@@ -1582,3 +1582,62 @@ spec:
                             hostPort: 25000
                             protocol: TCP
                     hostNetwork: true
+    - name: security-policy-no-ranges-functional
+      gatorBlock: security-policy-no-ranges-functional
+      defaultObjectBase: ""
+      template: ../rendered/constraint-template.yaml
+      constraint: constraints/policy_2.yaml
+      cases:
+        - name: denied-hostnetwork-true-without-ranges
+          violations: "yes"
+          assertionMessage: ""
+          fields:
+            - path: spec.hostNetwork
+              scenario: positive
+          exception: ""
+          exceptionRef: ""
+          object:
+            base: admissionPod
+            merge:
+              metadata:
+                name: denied-hostnetwork-true-without-ranges
+              spec:
+                hostNetwork: true
+        - name: allowed-no-hostnetwork-without-ranges
+          violations: "no"
+          assertionMessage: ""
+          fields:
+            - path: spec.hostNetwork
+              scenario: negative
+          exception: ""
+          exceptionRef: ""
+          object:
+            base: admissionPod
+            merge:
+              metadata:
+                name: allowed-no-hostnetwork-without-ranges
+              spec:
+                hostNetwork: false
+        - name: allowed-hostport-without-ranges
+          violations: "no"
+          assertionMessage: ""
+          fields:
+            - path: spec.hostNetwork
+              scenario: absent
+            - path: spec.containers[].ports[].hostPort
+              scenario: positive
+          exception: ""
+          exceptionRef: ""
+          object:
+            base: admissionPod
+            merge:
+              metadata:
+                name: allowed-hostport-without-ranges
+              spec:
+                containers:
+                  - image: nginx
+                    name: nginx
+                    ports:
+                      - containerPort: 25000
+                        hostPort: 25000
+                        protocol: TCP

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-host-network/test_profile.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/test_cases/constraints/security/allow-host-network/test_profile.yaml
@@ -8,4 +8,5 @@ spec:
     expectedTestBlockNames:
       - pss-baseline-functional
       - security-policy-functional
+      - security-policy-no-ranges-functional
       - security-policy-spe-pod


### PR DESCRIPTION
## Description

A `SecurityPolicy` that forbids host networking and says nothing about host ports silently did nothing:

```yaml
spec:
  enforcementAction: Deny
  policies:
    allowHostNetwork: false
```

`allowedHostPorts` is optional, so the chart renders no `parameters.ranges` for such a policy. The Rego read that parameter unconditionally through `port_ranges(false) := input.parameters.ranges`, and in Rego an absent key makes the expression undefined, which makes the whole enclosing `violation` rule undefined. No violation was produced — not for host ports, and not for `hostNetwork` either, even though that check had already concluded the pod was in breach.

The port check is now total. An absent `ranges` means what the CRD documents for an omitted field — no restriction on host ports — while an empty list keeps forbidding every one of them, and an exception that names host ports still governs them on its own.

Pod Security Standards were never affected: they always render `ranges`, empty when the standard forbids host ports.

The test suite gains a constraint with no `ranges` at all, covering a denied `hostNetwork: true`, an allowed pod without host networking, and an allowed host port.

## Why do we need it, and what problem does it solve?

This is a silent policy bypass. The policy reports `SYNCED: True`, the constraint exists in the cluster and Gatekeeper enforces it — it simply never finds a violation. Nothing in the status, the audit or the Grafana dashboard distinguishes it from a policy that is genuinely satisfied, so an operator has no way to notice that host networking is not actually being denied.

Found while testing #23003 on a cluster: a policy written to confirm that change did not deny what it was written to deny.

## Why do we need it in the patch release (if we do)?

Worth backporting. A cluster relying on such a policy to forbid host networking is unprotected today, and the fix is confined to one Rego rule with no change to any other policy's behaviour.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: A SecurityPolicy that sets `allowHostNetwork` without `allowedHostPorts` no longer stops denying host networking.
impact: |
  Such a policy previously produced a constraint that never reported a violation, so host networking went undenied while the policy appeared to be in force. It now denies as written. Review clusters where a SecurityPolicy sets `allowHostNetwork: false` and omits `allowedHostPorts`: workloads that were running with `hostNetwork: true` in scope of that policy start being rejected.
impact_level: high
```
